### PR TITLE
Add a mobile-first Codoxear shell

### DIFF
--- a/web/src/app/AppShell.test.tsx
+++ b/web/src/app/AppShell.test.tsx
@@ -298,7 +298,7 @@ describe("AppShell", () => {
     expect(announcementsButton?.querySelector("svg")).not.toBeNull();
   });
 
-  it("renders the conversation tools trigger in the Sessions slot on narrow viewports", () => {
+  it("renders bottom navigation on narrow viewports and defaults to the sessions page without an active session", () => {
     const originalMatchMedia = window.matchMedia;
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
@@ -316,11 +316,12 @@ describe("AppShell", () => {
 
     try {
       renderAppShell({ activeSessionId: null, diagnostics: null });
-      const trigger = findButtonByAriaLabel("Conversation tools");
-      expect(trigger).not.toBeNull();
-      expect(trigger?.disabled).toBe(false);
-      expect(trigger?.closest(".conversationToolbarGroupPrimary")).not.toBeNull();
-      expect(getRoot().querySelector(".mobileSheetTrigger")).toBeNull();
+      expect(getRoot().querySelector('[data-testid="mobile-shell"]')).not.toBeNull();
+      expect(findButtonByText("Sessions")).not.toBeNull();
+      expect(findButtonByText("Chat")).not.toBeNull();
+      expect(findButtonByText("Tools")).not.toBeNull();
+      expect(findButtonByAriaLabel("Conversation tools")).toBeNull();
+      expect(getRoot().querySelector('[data-testid="sessions-surface"]')).not.toBeNull();
     } finally {
       Object.defineProperty(window, "matchMedia", {
         configurable: true,
@@ -340,7 +341,7 @@ describe("AppShell", () => {
     expect(findButtonByAriaLabel("Interrupt (Esc)")?.querySelector("svg")).not.toBeNull();
   });
 
-  it("renders a grouped toolbar menu on narrow viewports", async () => {
+  it("switches to the tools page on narrow viewports", async () => {
     const originalMatchMedia = window.matchMedia;
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
@@ -360,35 +361,19 @@ describe("AppShell", () => {
       renderAppShell({ diagnostics: { status: "ok" } });
       await flush();
 
-      const menuButton = findButtonByAriaLabel("Conversation tools");
-      expect(menuButton).not.toBeNull();
-      expect(findButtonByAriaLabel("Files")).toBeNull();
-      expect(findButtonByAriaLabel("Workspace")).toBeNull();
+      expect(getRoot().textContent).toContain("Active session");
+      expect(findButtonByAriaLabel("Conversation tools")).toBeNull();
 
       act(() => {
-        menuButton?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+        findButtonByText("Tools")?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
       });
       await flush();
 
-      const sessionsButton = findButtonByAriaLabel("Sessions");
-      const filesButton = findButtonByAriaLabel("Files");
-      const workspaceButton = findButtonByAriaLabel("Workspace");
-      const harnessButton = findButtonByAriaLabel("Harness mode");
-      const interruptButton = findButtonByAriaLabel("Interrupt (Esc)");
-
-      expect(sessionsButton).not.toBeNull();
-      expect(filesButton).not.toBeNull();
-      expect(workspaceButton).not.toBeNull();
-      expect(harnessButton).not.toBeNull();
-      expect(interruptButton).not.toBeNull();
-      expect(sessionsButton?.querySelector("svg")).not.toBeNull();
-      expect(filesButton?.querySelector("svg")).not.toBeNull();
-      expect(workspaceButton?.querySelector("svg")).not.toBeNull();
-      expect(harnessButton?.querySelector("svg")).not.toBeNull();
-      expect(interruptButton?.querySelector("svg")).not.toBeNull();
-      expect(interruptButton?.className).toContain("conversationMenuItemDanger");
-      expect(sessionsButton?.className).toContain("conversationMenuItem");
-      expect(filesButton?.className).toContain("conversationMenuItem");
+      expect(getRoot().textContent).toContain("Secondary actions");
+      expect(findButtonByText("Files")).not.toBeNull();
+      expect(findButtonByText("Workspace")).not.toBeNull();
+      expect(findButtonByText("Harness")).not.toBeNull();
+      expect(findButtonByText("Settings")).not.toBeNull();
     } finally {
       Object.defineProperty(window, "matchMedia", {
         configurable: true,
@@ -415,7 +400,7 @@ describe("AppShell", () => {
     expect(dialog?.textContent).toContain("Diagnostics");
   });
 
-  it("opens workspace details in the mobile sheet on narrow viewports", async () => {
+  it("opens workspace details from the tools page on narrow viewports", async () => {
     const originalMatchMedia = window.matchMedia;
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
@@ -435,25 +420,23 @@ describe("AppShell", () => {
       renderAppShell({ diagnostics: { status: "ok" } });
       await flush();
 
-      const menuButton = findButtonByAriaLabel("Conversation tools");
-      expect(menuButton).not.toBeNull();
       act(() => {
-        menuButton?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+        findButtonByText("Tools")?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
       });
       await flush();
 
-      const button = findButtonByAriaLabel("Workspace");
+      const button = findButtonByText("Workspace");
       expect(button).not.toBeNull();
       act(() => {
         button?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
       });
       await flush();
 
-      const mobileSheet = getRoot().querySelector('[role="dialog"][aria-labelledby="mobile-workspace-title"]');
-      expect(mobileSheet).not.toBeNull();
-      expect(getRoot().querySelector("[data-testid='workspace-dialog']")).toBeNull();
-      expect(mobileSheet?.textContent).toContain("Workspace");
-      expect(mobileSheet?.textContent).toContain("Diagnostics");
+      const dialog = getRoot().querySelector("[data-testid='workspace-dialog']");
+      expect(dialog).not.toBeNull();
+      expect(getRoot().querySelector('[role="dialog"][aria-labelledby="mobile-workspace-title"]')).toBeNull();
+      expect(dialog?.textContent).toContain("Workspace");
+      expect(dialog?.textContent).toContain("Diagnostics");
     } finally {
       Object.defineProperty(window, "matchMedia", {
         configurable: true,
@@ -462,7 +445,7 @@ describe("AppShell", () => {
     }
   });
 
-  it("opens the sessions sheet from the grouped toolbar menu on narrow viewports", async () => {
+  it("switches back to the sessions page from bottom navigation on narrow viewports", async () => {
     const originalMatchMedia = window.matchMedia;
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
@@ -482,23 +465,14 @@ describe("AppShell", () => {
       renderAppShell({ diagnostics: { status: "ok" } });
       await flush();
 
-      const menuButton = findButtonByAriaLabel("Conversation tools");
-      expect(menuButton).not.toBeNull();
+      expect(getRoot().textContent).toContain("Active session");
       act(() => {
-        menuButton?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+        findButtonByText("Sessions")?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
       });
       await flush();
 
-      const sessionsButton = findButtonByAriaLabel("Sessions");
-      expect(sessionsButton).not.toBeNull();
-      act(() => {
-        sessionsButton?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
-      });
-      await flush();
-
-      const mobileSheet = getRoot().querySelector('[role="dialog"][aria-labelledby="mobile-sessions-title"]');
-      expect(mobileSheet).not.toBeNull();
-      expect(mobileSheet?.textContent).toContain("Sessions");
+      expect(getRoot().querySelector('[data-testid="sessions-surface"]')).not.toBeNull();
+      expect(getRoot().textContent).toContain("Continue where you left off");
     } finally {
       Object.defineProperty(window, "matchMedia", {
         configurable: true,

--- a/web/src/app/AppShell.tsx
+++ b/web/src/app/AppShell.tsx
@@ -8,6 +8,7 @@ import { TodoPopover } from "../components/workspace/TodoPopover";
 import { AppShellSidebar } from "./app-shell/AppShellSidebar";
 import { AppShellToolbar } from "./app-shell/AppShellToolbar";
 import { AppShellWorkspaceOverlays } from "./app-shell/AppShellWorkspaceOverlays";
+import { MobileShell } from "./app-shell/MobileShell";
 import { VoiceSettingsDialog } from "./app-shell/VoiceSettingsDialog";
 import { useAppShellAudio } from "./app-shell/useAppShellAudio";
 import { useAppShellNotifications } from "./app-shell/useAppShellNotifications";
@@ -184,8 +185,33 @@ export function AppShell() {
 
   const sessionUiMatchesActiveSession = !!activeSessionId && sessionUiSessionId === activeSessionId;
   const showInterruptAction = !activeSessionId || activeSessionBusy;
-  const showMobileSessionsTrigger = shouldUseMobileWorkspaceSheet();
-  const showMobileToolbarMenu = showMobileSessionsTrigger;
+  const [mobileLayout, setMobileLayout] = useState(() => shouldUseMobileWorkspaceSheet());
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(max-width: 880px)");
+    const update = () => {
+      setMobileLayout(mediaQuery.matches);
+    };
+
+    update();
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", update);
+    } else {
+      mediaQuery.addListener?.(update);
+    }
+
+    return () => {
+      if (typeof mediaQuery.removeEventListener === "function") {
+        mediaQuery.removeEventListener("change", update);
+      } else {
+        mediaQuery.removeListener?.(update);
+      }
+    };
+  }, []);
 
   const openFileViewer = (path = "", line: number | null = null, mode: FileViewMode | null = null) => {
     setFileViewerPath(path);
@@ -237,10 +263,6 @@ export function AppShell() {
   );
 
   const openWorkspace = () => {
-    if (shouldUseMobileWorkspaceSheet()) {
-      setDetailsOpen(true);
-      return;
-    }
     setWorkspaceOpen(true);
   };
 
@@ -334,30 +356,66 @@ export function AppShell() {
     <>
       <div className={shellClassName} data-testid="app-shell">
         <audio ref={liveAudioRef} className="liveAudioElement" preload="none" />
-        <aside className="sidebarColumn desktopSessionsRail">{renderSessionsRail()}</aside>
-        <section className="conversationColumn">
-          <AppShellToolbar
+        {mobileLayout ? (
+          <MobileShell
             activeSessionId={activeSessionId}
             activeTitle={activeTitle}
+            announcementEnabled={announcementEnabled}
+            announcementLabel={announcementLabel}
             canInterrupt={Boolean(activeSessionId && activeSessionBusy)}
-            showInterruptAction={showInterruptAction}
-            showMobileSessionsTrigger={showMobileSessionsTrigger}
-            showMobileToolbarMenu={showMobileToolbarMenu}
+            notificationLabel={notificationLabel}
+            notificationsEnabled={notificationsEnabled}
             onInterrupt={() => {
               void interruptActiveSession();
             }}
+            onLogout={() => {
+              void logout();
+            }}
+            onNewSession={() => setNewSessionOpen(true)}
+            onOpenFilePath={(path, line) => openFileViewer(path, line ?? null, "file")}
             onOpenFiles={() => openFileViewer()}
             onOpenHarness={() => setHarnessOpen(true)}
-            onOpenSessions={() => setSidebarOpen(true)}
+            onOpenSettings={() => openVoiceSettings()}
             onOpenTodo={() => setTodoViewerOpen(true)}
             onOpenWorkspace={openWorkspace}
+            onToggleAnnouncements={() => {
+              void toggleAnnouncements();
+              if (!announcementEnabled) {
+                void startAnnouncementPlayback(voiceSettings, { resetSource: true, force: true });
+              }
+            }}
+            onToggleNotifications={() => {
+              void toggleNotifications();
+            }}
           />
-          <ConversationPane
-            key={activeSessionId || "no-session"}
-            onOpenFilePath={(path, line) => openFileViewer(path, line ?? null, "file")}
-          />
-          <Composer />
-        </section>
+        ) : (
+          <>
+            <aside className="sidebarColumn desktopSessionsRail">{renderSessionsRail()}</aside>
+            <section className="conversationColumn">
+              <AppShellToolbar
+                activeSessionId={activeSessionId}
+                activeTitle={activeTitle}
+                canInterrupt={Boolean(activeSessionId && activeSessionBusy)}
+                showInterruptAction={showInterruptAction}
+                showMobileSessionsTrigger={false}
+                showMobileToolbarMenu={false}
+                onInterrupt={() => {
+                  void interruptActiveSession();
+                }}
+                onOpenFiles={() => openFileViewer()}
+                onOpenHarness={() => setHarnessOpen(true)}
+                onOpenSessions={() => setSidebarOpen(true)}
+                onOpenTodo={() => setTodoViewerOpen(true)}
+                onOpenWorkspace={openWorkspace}
+              />
+              <ConversationPane
+                key={activeSessionId || "no-session"}
+                onOpenFilePath={(path, line) => openFileViewer(path, line ?? null, "file")}
+              />
+              <Composer />
+            </section>
+          </>
+        )}
       </div>
       <AppShellWorkspaceOverlays
         activeSessionId={activeSessionId}

--- a/web/src/app/app-shell/AppShellWorkspaceOverlays.tsx
+++ b/web/src/app/app-shell/AppShellWorkspaceOverlays.tsx
@@ -95,7 +95,7 @@ export function AppShellWorkspaceOverlays({
           onCloseWorkspace();
         }
       }}>
-        <DialogContent className="workspaceDialog max-w-none" titleId="workspace-dialog-title">
+        <DialogContent className="workspaceDialog mobileDetailDialog max-w-none" titleId="workspace-dialog-title">
           <div data-testid="workspace-dialog" className="workspaceDialogBody">
             <DialogHeader className="workspaceDialogHeader">
               <div className="flex items-center justify-between gap-3">
@@ -117,7 +117,7 @@ export function AppShellWorkspaceOverlays({
           onCloseTodoViewer();
         }
       }}>
-        <DialogContent className="todoViewerDialog max-w-2xl" titleId="todo-viewer-dialog-title">
+        <DialogContent className="todoViewerDialog mobileDetailDialog max-w-2xl" titleId="todo-viewer-dialog-title">
           <div className="todoViewerDialogFrame">
             <DialogHeader className="todoViewerDialogHeader">
               <div className="flex items-center justify-between gap-3">

--- a/web/src/app/app-shell/MobileShell.tsx
+++ b/web/src/app/app-shell/MobileShell.tsx
@@ -1,0 +1,240 @@
+import { useEffect, useState } from "preact/hooks";
+import { Button } from "@/components/ui/button";
+import { SessionsPane } from "@/components/sessions/SessionsPane";
+import { Composer } from "@/components/composer/Composer";
+import { ConversationPane } from "@/components/conversation/ConversationPane";
+import { FileIcon, HarnessIcon, StopIcon, TodoListIcon, WorkspaceIcon } from "./icons";
+
+export type MobileShellTab = "sessions" | "chat" | "tools";
+
+interface MobileShellProps {
+  activeSessionId: string | null;
+  activeTitle: string;
+  announcementEnabled: boolean;
+  announcementLabel: string;
+  canInterrupt: boolean;
+  notificationLabel: string;
+  notificationsEnabled: boolean;
+  onInterrupt(): void;
+  onLogout(): void;
+  onNewSession(): void;
+  onOpenFilePath(path: string, line?: number | null): void;
+  onOpenFiles(): void;
+  onOpenHarness(): void;
+  onOpenSettings(): void;
+  onOpenTodo(): void;
+  onOpenWorkspace(): void;
+  onToggleAnnouncements(): void;
+  onToggleNotifications(): void;
+}
+
+function MobileToolsSection({
+  announcementEnabled,
+  announcementLabel,
+  notificationsEnabled,
+  notificationLabel,
+  onLogout,
+  onNewSession,
+  onOpenFiles,
+  onOpenHarness,
+  onOpenSettings,
+  onOpenTodo,
+  onOpenWorkspace,
+  onToggleAnnouncements,
+  onToggleNotifications,
+}: Omit<MobileShellProps, "activeSessionId" | "activeTitle" | "canInterrupt" | "onInterrupt" | "onOpenFilePath">) {
+  return (
+    <section className="mobileToolsPage" aria-label="Tools">
+      <header className="mobileSectionHeader">
+        <div>
+          <p className="mobileSectionEyebrow">Secondary actions</p>
+          <h2 className="mobileSectionTitle">Tools</h2>
+        </div>
+      </header>
+      <div className="mobileToolsGrid">
+        <Button type="button" variant="outline" className="mobileToolCard" onClick={onNewSession}>
+          <span className="mobileToolCardIcon" aria-hidden="true">+</span>
+          <span className="mobileToolCardText">
+            <strong>New session</strong>
+            <span>Start a new browser-owned session.</span>
+          </span>
+        </Button>
+        <Button type="button" variant="outline" className="mobileToolCard" onClick={onOpenFiles}>
+          <FileIcon />
+          <span className="mobileToolCardText">
+            <strong>Files</strong>
+            <span>Inspect tracked files and open diffs.</span>
+          </span>
+        </Button>
+        <Button type="button" variant="outline" className="mobileToolCard" onClick={onOpenTodo}>
+          <TodoListIcon />
+          <span className="mobileToolCardText">
+            <strong>Todo list</strong>
+            <span>Review the current task snapshot.</span>
+          </span>
+        </Button>
+        <Button type="button" variant="outline" className="mobileToolCard" onClick={onOpenWorkspace}>
+          <WorkspaceIcon />
+          <span className="mobileToolCardText">
+            <strong>Workspace</strong>
+            <span>Open diagnostics, queue state, and files.</span>
+          </span>
+        </Button>
+        <Button type="button" variant="outline" className="mobileToolCard" onClick={onOpenHarness}>
+          <HarnessIcon />
+          <span className="mobileToolCardText">
+            <strong>Harness</strong>
+            <span>Inspect or adjust automation controls.</span>
+          </span>
+        </Button>
+        <Button type="button" variant="outline" className="mobileToolCard" onClick={onOpenSettings}>
+          <span className="mobileToolCardIcon" aria-hidden="true">S</span>
+          <span className="mobileToolCardText">
+            <strong>Settings</strong>
+            <span>Voice, theme, and composer preferences.</span>
+          </span>
+        </Button>
+      </div>
+      <div className="mobileToggleStack">
+        <Button type="button" variant="outline" className="mobileToggleButton" onClick={onToggleNotifications}>
+          <span className="mobileToggleLabel">Notifications</span>
+          <span className="mobileToggleValue">{notificationsEnabled ? "On" : "Off"}</span>
+          <span className="visuallyHidden">{notificationLabel}</span>
+        </Button>
+        <Button type="button" variant="outline" className="mobileToggleButton" onClick={onToggleAnnouncements}>
+          <span className="mobileToggleLabel">Announcements</span>
+          <span className="mobileToggleValue">{announcementEnabled ? "On" : "Off"}</span>
+          <span className="visuallyHidden">{announcementLabel}</span>
+        </Button>
+        <Button type="button" variant="outline" className="mobileToggleButton" onClick={onLogout}>
+          <span className="mobileToggleLabel">Log out</span>
+          <span className="mobileToggleValue">Session</span>
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+function blurActiveInteractiveElement() {
+  if (typeof document === "undefined") {
+    return;
+  }
+  const active = document.activeElement;
+  if (active instanceof HTMLElement) {
+    active.blur();
+  }
+}
+
+export function MobileShell({
+  activeSessionId,
+  activeTitle,
+  announcementEnabled,
+  announcementLabel,
+  canInterrupt,
+  notificationLabel,
+  notificationsEnabled,
+  onInterrupt,
+  onLogout,
+  onNewSession,
+  onOpenFilePath,
+  onOpenFiles,
+  onOpenHarness,
+  onOpenSettings,
+  onOpenTodo,
+  onOpenWorkspace,
+  onToggleAnnouncements,
+  onToggleNotifications,
+}: MobileShellProps) {
+  const [tab, setTab] = useState<MobileShellTab>(activeSessionId ? "chat" : "sessions");
+
+  useEffect(() => {
+    if (activeSessionId) {
+      setTab("chat");
+    }
+    blurActiveInteractiveElement();
+  }, [activeSessionId]);
+
+  useEffect(() => {
+    if (tab !== "chat") {
+      blurActiveInteractiveElement();
+    }
+  }, [tab]);
+
+  return (
+    <div className="mobileShell" data-testid="mobile-shell">
+      <section className="mobileShellBody">
+        {tab === "sessions" ? (
+          <div className="mobilePane mobileSessionsPane">
+            <SessionsPane onNewSession={onNewSession} />
+          </div>
+        ) : null}
+        {tab === "chat" ? (
+          <section className="mobilePane mobileChatPane">
+            <header className="mobileChatHeader">
+              <div className="mobileChatHeading">
+                <p className="mobileSectionEyebrow">Active session</p>
+                <h1 className="mobileChatTitle">{activeSessionId ? activeTitle : "No session selected"}</h1>
+              </div>
+              {canInterrupt ? (
+                <Button type="button" variant="outline" size="sm" className="mobileInterruptButton" onClick={onInterrupt}>
+                  <StopIcon />
+                  <span>Interrupt</span>
+                </Button>
+              ) : null}
+            </header>
+            <ConversationPane
+              key={activeSessionId || "no-session"}
+              onOpenFilePath={(path, line) => onOpenFilePath(path, line ?? null)}
+            />
+            <Composer />
+          </section>
+        ) : null}
+        {tab === "tools" ? (
+          <div className="mobilePane mobileToolsPane">
+            <MobileToolsSection
+              announcementEnabled={announcementEnabled}
+              announcementLabel={announcementLabel}
+              notificationLabel={notificationLabel}
+              notificationsEnabled={notificationsEnabled}
+              onLogout={onLogout}
+              onNewSession={onNewSession}
+              onOpenFiles={onOpenFiles}
+              onOpenHarness={onOpenHarness}
+              onOpenSettings={onOpenSettings}
+              onOpenTodo={onOpenTodo}
+              onOpenWorkspace={onOpenWorkspace}
+              onToggleAnnouncements={onToggleAnnouncements}
+              onToggleNotifications={onToggleNotifications}
+            />
+          </div>
+        ) : null}
+      </section>
+      <nav className="mobileBottomNav" aria-label="Primary">
+        <Button
+          type="button"
+          variant={tab === "sessions" ? "default" : "outline"}
+          className="mobileBottomNavButton"
+          onClick={() => setTab("sessions")}
+        >
+          Sessions
+        </Button>
+        <Button
+          type="button"
+          variant={tab === "chat" ? "default" : "outline"}
+          className="mobileBottomNavButton"
+          onClick={() => setTab("chat")}
+        >
+          Chat
+        </Button>
+        <Button
+          type="button"
+          variant={tab === "tools" ? "default" : "outline"}
+          className="mobileBottomNavButton"
+          onClick={() => setTab("tools")}
+        >
+          Tools
+        </Button>
+      </nav>
+    </div>
+  );
+}

--- a/web/src/components/composer/Composer.tsx
+++ b/web/src/components/composer/Composer.tsx
@@ -51,6 +51,14 @@ function shouldUseMobileComposerAutosize() {
   return window.matchMedia(MOBILE_COMPOSER_QUERY).matches;
 }
 
+function isCompactMobileViewport() {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+
+  return window.matchMedia("(max-width: 880px), (pointer: coarse)").matches;
+}
+
 function syncComposerTextareaHeight(textarea: HTMLTextAreaElement | null, enabled: boolean) {
   if (!textarea) {
     return;
@@ -323,6 +331,52 @@ export function Composer() {
   useLayoutEffect(() => {
     syncComposerTextareaHeight(textareaRef.current, mobileComposerAutosize);
   }, [draft, mobileComposerAutosize]);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+
+    if (document.activeElement === textarea) {
+      textarea.blur();
+    }
+    syncComposerTextareaHeight(textarea, mobileComposerAutosize);
+  }, [activeSessionId, mobileComposerAutosize]);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea || typeof window === "undefined") {
+      return;
+    }
+
+    const alignIntoView = () => {
+      if (document.activeElement !== textarea || !isCompactMobileViewport()) {
+        return;
+      }
+      window.requestAnimationFrame(() => {
+        textarea.scrollIntoView({ block: "nearest", inline: "nearest" });
+      });
+    };
+
+    const handleFocus = () => {
+      alignIntoView();
+      window.setTimeout(alignIntoView, 120);
+    };
+    const handleViewportResize = () => {
+      syncComposerTextareaHeight(textarea, mobileComposerAutosize);
+      alignIntoView();
+    };
+
+    textarea.addEventListener("focus", handleFocus);
+    window.visualViewport?.addEventListener("resize", handleViewportResize);
+    window.addEventListener("resize", handleViewportResize);
+    return () => {
+      textarea.removeEventListener("focus", handleFocus);
+      window.visualViewport?.removeEventListener("resize", handleViewportResize);
+      window.removeEventListener("resize", handleViewportResize);
+    };
+  }, [activeSessionId, mobileComposerAutosize]);
 
   useEffect(() => {
     if (!activeSessionId || !activeSessionIsPi || activeSessionPending || slashQuery === null) {

--- a/web/src/components/workspace/FileViewerDialog.test.tsx
+++ b/web/src/components/workspace/FileViewerDialog.test.tsx
@@ -166,6 +166,48 @@ describe("FileViewerDialog", () => {
     expect((api as any).getFiles).toHaveBeenCalledTimes(2);
   });
 
+  it("opens explicit files in file mode on compact viewports and exposes the browser toggle", async () => {
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(max-width: 880px), (pointer: coarse)",
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn().mockReturnValue(false),
+      })),
+    });
+
+    const { api } = await import("../../lib/api");
+    (api as any).getFiles.mockResolvedValue({ ok: true, path: "", entries: [] });
+    (api as any).getFileRead.mockResolvedValue({ ok: true, kind: "text", text: "# Hello\n\nBody" });
+
+    root = document.createElement("div");
+    document.body.appendChild(root);
+    try {
+      await act(async () => {
+        render(
+          <FileViewerDialog open sessionId="sess-mobile-file" initialPath="README.md" onClose={() => undefined} />,
+          root!,
+        );
+        await settle(8);
+      });
+
+      expect((api as any).getFileRead).toHaveBeenCalledWith("sess-mobile-file", "README.md", expect.any(AbortSignal));
+      expect(root.textContent).toContain("Browser");
+      expect(root.textContent).toContain("README.md");
+    } finally {
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        value: originalMatchMedia,
+      });
+    }
+  });
+
   it("can switch from diff mode to file and markdown preview modes", async () => {
     const { api } = await import("../../lib/api");
     (api as any).getFiles.mockResolvedValue({ ok: true, path: "", entries: [] });

--- a/web/src/components/workspace/FileViewerDialog.tsx
+++ b/web/src/components/workspace/FileViewerDialog.tsx
@@ -138,9 +138,16 @@ function renderMarkdownPreview(value: string) {
   );
 }
 
+function shouldUseCompactFileViewer() {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  return window.matchMedia("(max-width: 880px), (pointer: coarse)").matches;
+}
+
 function PlainTextWorkspace({ value }: { value: string }) {
   return (
-    <ScrollArea className="h-[58vh] rounded-2xl border border-border/60 bg-slate-950 p-4 text-slate-100" data-testid="file-text-view">
+    <ScrollArea className="fileViewerSurface rounded-2xl border border-border/60 bg-slate-950 p-4 text-slate-100" data-testid="file-text-view">
       <pre data-testid="file-text-body" className="whitespace-pre-wrap break-words text-sm leading-6">{value}</pre>
     </ScrollArea>
   );
@@ -148,7 +155,7 @@ function PlainTextWorkspace({ value }: { value: string }) {
 
 function PlainDiffWorkspace({ baseText, currentText }: { baseText: string; currentText: string }) {
   return (
-    <div className="grid h-[58vh] grid-cols-2 gap-4" data-testid="file-diff-view">
+    <div className="fileViewerDiffSurface grid gap-4" data-testid="file-diff-view">
       <ScrollArea className="rounded-2xl border border-border/60 bg-slate-950 p-4 text-slate-100">
         <p className="mb-3 text-xs uppercase tracking-[0.14em] text-slate-400">Base</p>
         <pre data-testid="file-diff-base" className="whitespace-pre-wrap break-words text-sm leading-6">{baseText}</pre>
@@ -257,6 +264,8 @@ export function FileViewerDialog({
   const [error, setError] = useState("");
   const [payload, setPayload] = useState<SessionFileReadResponse | null>(null);
   const [diffPayload, setDiffPayload] = useState<GitFileVersionsResponse | null>(null);
+  const [compactLayout, setCompactLayout] = useState(() => shouldUseCompactFileViewer());
+  const [showBrowser, setShowBrowser] = useState(() => !shouldUseCompactFileViewer());
   const listRequestIdRef = useRef(0);
   const openRequestIdRef = useRef(0);
   const fileOpenAbortRef = useRef<AbortController | null>(null);
@@ -319,6 +328,34 @@ export function FileViewerDialog({
   }, [open, openRequestKey, runtimeId, sessionId]);
 
   useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(max-width: 880px), (pointer: coarse)");
+    const update = () => {
+      const nextCompact = mediaQuery.matches;
+      setCompactLayout(nextCompact);
+      setShowBrowser((current) => (nextCompact ? current : true));
+    };
+
+    update();
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", update);
+    } else {
+      mediaQuery.addListener?.(update);
+    }
+
+    return () => {
+      if (typeof mediaQuery.removeEventListener === "function") {
+        mediaQuery.removeEventListener("change", update);
+      } else {
+        mediaQuery.removeListener?.(update);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
     if (!open) {
       return;
     }
@@ -330,7 +367,8 @@ export function FileViewerDialog({
       setPayload(null);
       setDiffPayload(null);
       setError("");
-      setViewMode("diff");
+      setViewMode(compactLayout ? "file" : "diff");
+      setShowBrowser(true);
       return;
     }
 
@@ -338,8 +376,9 @@ export function FileViewerDialog({
     setPath(preferredPath);
     setLine(preferredLine);
     setViewMode(initialPath ? normalizeViewMode(initialMode || "file") : "diff");
+    setShowBrowser(compactLayout ? !preferredPath : true);
     setError("");
-  }, [initialLine, initialMode, initialPath, open, openRequestKey, rememberedPath, rememberedSelection?.line]);
+  }, [compactLayout, initialLine, initialMode, initialPath, open, openRequestKey, rememberedPath, rememberedSelection?.line]);
 
   useEffect(() => {
     if (!open || !sessionId) {
@@ -471,7 +510,7 @@ export function FileViewerDialog({
 
   return (
     <Dialog open={open}>
-      <DialogContent className="fileViewerDialog max-w-6xl p-0" titleId="file-viewer-title">
+      <DialogContent className="fileViewerDialog mobileDetailDialog max-w-6xl p-0" titleId="file-viewer-title">
         <DialogHeader className="border-b border-border/60 px-5 py-4">
           <div className="flex items-start justify-between gap-3">
             <div>
@@ -484,46 +523,62 @@ export function FileViewerDialog({
             <Button type="button" variant="ghost" size="sm" onClick={onClose}>Close</Button>
           </div>
         </DialogHeader>
-        <div className="grid min-h-[65vh] grid-cols-[260px_minmax(0,1fr)] gap-0 max-md:grid-cols-1">
-          <aside className="border-r border-border/60 bg-muted/20 p-4 max-md:border-b max-md:border-r-0">
-            <label className="mb-3 block text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Path</label>
-            <Input
-              value={path}
-              onInput={(event) => {
-                setPath(event.currentTarget.value);
-                setLine(null);
-              }}
-              placeholder="src/app.tsx"
-            />
-            <ScrollArea className="mt-4 h-[calc(65vh-8rem)] rounded-2xl border border-border/60 bg-background/80 p-2 max-md:h-48">
-              <div className="space-y-1">
-                {treeLoading ? (
-                  <p className="px-2 py-3 text-sm text-muted-foreground">Loading files…</p>
-                ) : treeError ? (
-                  <p className="px-2 py-3 text-sm text-destructive">{treeError}</p>
-                ) : tree.length ? (
-                  tree.map((entry) => (
-                    <FileTreeNodeRow
-                      key={entry.path}
-                      depth={0}
-                      node={entry}
-                      onRetry={loadDirectory}
-                      onSelect={(nextPath) => {
-                        setPath(nextPath);
-                        setLine(null);
-                      }}
-                      onToggle={toggleDirectory}
-                      selectedPath={normalizedPath}
-                    />
-                  ))
-                ) : (
-                  <p className="px-2 py-3 text-sm text-muted-foreground">No files available.</p>
-                )}
+        <div className={`fileViewerLayout grid min-h-[65vh] gap-0 ${compactLayout ? "compact" : "desktop"}`}>
+          {(!compactLayout || showBrowser) ? (
+            <aside className="fileViewerSidebar border-r border-border/60 bg-muted/20 p-4">
+              <div className="flex items-center justify-between gap-3">
+                <label className="block text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Path</label>
+                {compactLayout ? (
+                  <Button type="button" variant="ghost" size="sm" onClick={() => setShowBrowser(false)}>Hide browser</Button>
+                ) : null}
               </div>
-            </ScrollArea>
-          </aside>
-          <section className="min-w-0 p-4">
-            <div className="mb-4 flex flex-wrap items-center gap-2">
+              <Input
+                value={path}
+                onInput={(event) => {
+                  setPath(event.currentTarget.value);
+                  setLine(null);
+                }}
+                placeholder="src/app.tsx"
+              />
+              <ScrollArea className="fileViewerTree mt-4 rounded-2xl border border-border/60 bg-background/80 p-2">
+                <div className="space-y-1">
+                  {treeLoading ? (
+                    <p className="px-2 py-3 text-sm text-muted-foreground">Loading files…</p>
+                  ) : treeError ? (
+                    <p className="px-2 py-3 text-sm text-destructive">{treeError}</p>
+                  ) : tree.length ? (
+                    tree.map((entry) => (
+                      <FileTreeNodeRow
+                        key={entry.path}
+                        depth={0}
+                        node={entry}
+                        onRetry={loadDirectory}
+                        onSelect={(nextPath) => {
+                          setPath(nextPath);
+                          setLine(null);
+                          if (compactLayout) {
+                            setViewMode(isMarkdownFile(nextPath) ? "preview" : "file");
+                            setShowBrowser(false);
+                          }
+                        }}
+                        onToggle={toggleDirectory}
+                        selectedPath={normalizedPath}
+                      />
+                    ))
+                  ) : (
+                    <p className="px-2 py-3 text-sm text-muted-foreground">No files available.</p>
+                  )}
+                </div>
+              </ScrollArea>
+            </aside>
+          ) : null}
+          <section className="fileViewerBody min-w-0 p-4">
+            <div className="fileViewerToolbar mb-4 flex flex-wrap items-center gap-2">
+              {compactLayout ? (
+                <Button type="button" variant="outline" size="sm" onClick={() => setShowBrowser((current) => !current)}>
+                  {showBrowser ? "Viewer" : "Browser"}
+                </Button>
+              ) : null}
               <Button type="button" variant={viewMode === "diff" ? "default" : "outline"} size="sm" onClick={() => setViewMode("diff")} disabled={!normalizedPath}>Diff</Button>
               <Button type="button" variant={viewMode === "file" ? "default" : "outline"} size="sm" onClick={() => setViewMode("file")} disabled={!normalizedPath}>File</Button>
               <Button type="button" variant={viewMode === "preview" ? "default" : "outline"} size="sm" onClick={() => setViewMode("preview")} disabled={!normalizedPath || !canPreview}>Preview</Button>
@@ -541,12 +596,12 @@ export function FileViewerDialog({
               />
             ) : null}
             {!loading && !error && payload?.kind === "image" && payload.image_url ? (
-              <div className="flex h-[58vh] items-start justify-center overflow-auto rounded-2xl border border-border/60 bg-background/70 p-4">
+              <div className="fileViewerSurface flex items-start justify-center overflow-auto rounded-2xl border border-border/60 bg-background/70 p-4">
                 <img src={payload.image_url} alt={normalizedPath || "Session file"} className="max-h-full rounded-xl object-contain" />
               </div>
             ) : null}
             {!loading && !error && viewMode === "preview" && canPreview && payload?.kind !== "image" ? (
-              <ScrollArea className="filePreview h-[58vh] rounded-2xl border border-border/60 bg-background/70 p-4" data-testid="file-preview-view">
+              <ScrollArea className="fileViewerSurface filePreview rounded-2xl border border-border/60 bg-background/70 p-4" data-testid="file-preview-view">
                 {renderMarkdownPreview(payload?.text || "")}
               </ScrollArea>
             ) : null}

--- a/web/src/components/workspace/HarnessDialog.tsx
+++ b/web/src/components/workspace/HarnessDialog.tsx
@@ -86,7 +86,7 @@ export function HarnessDialog({ open, sessionId, runtimeId = null, onClose }: Ha
 
   return (
     <Dialog open={open}>
-      <DialogContent className="max-w-2xl" titleId="harness-dialog-title">
+      <DialogContent className="harnessDialog mobileDetailDialog max-w-2xl" titleId="harness-dialog-title">
         <DialogHeader>
           <div className="flex items-start justify-between gap-3">
             <div>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -398,6 +398,171 @@ select {
   box-shadow: 0 28px 64px rgba(15, 23, 42, 0.08);
 }
 
+.mobileShell {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+  border: 1px solid color-mix(in srgb, var(--legacy-border) 70%, white);
+  border-radius: 28px;
+  background: color-mix(in srgb, var(--panel) 97%, white);
+  box-shadow: 0 24px 56px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+}
+
+.mobileShellBody {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+}
+
+.mobilePane {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.mobileChatPane {
+  min-height: 0;
+  background: color-mix(in srgb, var(--panel) 97%, white);
+}
+
+.mobileChatHeader,
+.mobileSectionHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.9rem;
+  padding: 0.95rem 1rem 0.75rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--legacy-border) 78%, white);
+}
+
+.mobileChatHeading {
+  min-width: 0;
+}
+
+.mobileSectionEyebrow {
+  margin: 0 0 0.2rem;
+  color: var(--legacy-muted);
+  font-size: 0.73rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mobileSectionTitle,
+.mobileChatTitle {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.15;
+  color: var(--text);
+}
+
+.mobileChatTitle {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
+.mobileInterruptButton {
+  flex: 0 0 auto;
+}
+
+.mobileToolsPage {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-bottom: 1rem;
+  overflow-y: auto;
+}
+
+.mobileToolsGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  padding: 0 1rem;
+}
+
+.mobileToolCard {
+  min-height: 6.5rem;
+  padding: 0.9rem;
+  border-radius: 18px;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  text-align: left;
+  white-space: normal;
+}
+
+.mobileToolCardIcon {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.mobileToolCardText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+.mobileToolCardText strong {
+  font-size: 0.95rem;
+  line-height: 1.1;
+}
+
+.mobileToolCardText span {
+  color: var(--legacy-muted);
+  font-size: 0.78rem;
+  line-height: 1.3;
+}
+
+.mobileToggleStack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 0 1rem;
+}
+
+.mobileToggleButton {
+  min-height: 3.2rem;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.mobileToggleLabel {
+  font-weight: 600;
+}
+
+.mobileToggleValue {
+  color: var(--legacy-muted);
+}
+
+.mobileBottomNav {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.6rem;
+  padding: 0.75rem 0.9rem calc(0.75rem + env(safe-area-inset-bottom));
+  border-top: 1px solid color-mix(in srgb, var(--legacy-border) 78%, white);
+  background: color-mix(in srgb, var(--panel) 94%, white);
+}
+
+.mobileBottomNavButton {
+  min-height: 2.9rem;
+  border-radius: 999px;
+}
+
 .conversationToolbar {
   display: flex;
   align-items: center;
@@ -952,6 +1117,8 @@ select {
   overflow-y: auto;
   padding: 18px 18px 10px;
   min-height: 0;
+  overscroll-behavior-y: contain;
+  scroll-padding-bottom: 112px;
 }
 
 .conversationPane.emptyState {
@@ -1736,6 +1903,23 @@ select {
   overflow: hidden;
 }
 
+.fileViewerLayout.desktop {
+  grid-template-columns: 260px minmax(0, 1fr);
+}
+
+.fileViewerSurface {
+  height: min(58vh, 36rem);
+}
+
+.fileViewerDiffSurface {
+  height: min(58vh, 36rem);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.fileViewerTree {
+  height: calc(min(65vh, 40rem) - 8rem);
+}
+
 .workspaceDialog {
   display: flex;
   flex-direction: column;
@@ -2353,6 +2537,7 @@ select {
 :root[data-theme="dark"] .composerInterruptButton,
 :root[data-theme="dark"] .composerCommandMenu,
 :root[data-theme="dark"] .conversationColumn,
+:root[data-theme="dark"] .mobileShell,
 :root[data-theme="dark"] .conversationToolbar,
 :root[data-theme="dark"] .workspaceRail,
 :root[data-theme="dark"] .sidebarFooter,
@@ -2415,6 +2600,12 @@ select {
 @media (max-width: 880px) {
   .appShell.editorialShell {
     grid-template-columns: 1fr;
+    top: 0;
+    right: 0;
+    bottom: auto;
+    left: 0;
+    height: var(--appH, 100dvh);
+    max-height: var(--appH, 100dvh);
     padding: 0.45rem;
     gap: 0.45rem;
   }
@@ -2619,6 +2810,127 @@ select {
 
   .conversationPane {
     padding: 12px 10px 6px;
+    scroll-padding-bottom: 148px;
+  }
+
+  .mobileShell {
+    border-radius: 22px;
+  }
+
+  .mobileShellBody {
+    min-height: 0;
+  }
+
+  .mobileChatHeader,
+  .mobileSectionHeader {
+    padding: 0.85rem 0.9rem 0.7rem;
+  }
+
+  .mobileChatTitle,
+  .mobileSectionTitle {
+    font-size: 1rem;
+  }
+
+  .mobileToolsGrid {
+    grid-template-columns: minmax(0, 1fr);
+    padding: 0 0.9rem;
+  }
+
+  .mobileToggleStack {
+    padding: 0 0.9rem;
+  }
+
+  .workspaceCard {
+    border-radius: 1.15rem;
+  }
+
+  .workspaceTabsList {
+    gap: 0.4rem;
+    border-radius: 1rem;
+  }
+
+  .workspaceScroll {
+    padding-right: 0;
+  }
+
+  .workspacePanelGrid {
+    gap: 0.75rem;
+  }
+
+  .workspaceSurface {
+    padding: 0.8rem;
+    border-radius: 1rem;
+  }
+
+  .workspaceSurface h3 {
+    font-size: 0.92rem;
+  }
+
+  .workspaceCollection li {
+    padding: 0.65rem 0.75rem;
+    border-radius: 0.85rem;
+  }
+
+  .fieldBlock input,
+  .fieldBlock select,
+  .fieldBlock textarea {
+    font-size: 16px;
+  }
+
+  .toggleOption {
+    padding: 0.75rem;
+    border-radius: 1rem;
+  }
+
+  .fileViewerLayout.desktop,
+  .fileViewerLayout.compact {
+    grid-template-columns: minmax(0, 1fr);
+    min-height: 0;
+  }
+
+  .fileViewerSidebar {
+    border-right: 0;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  }
+
+  .fileViewerBody {
+    min-height: 0;
+  }
+
+  .fileViewerTree {
+    height: min(30vh, 16rem);
+  }
+
+  .fileViewerSurface,
+  .fileViewerDiffSurface {
+    height: min(48vh, 28rem);
+  }
+
+  .fileViewerDiffSurface {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .mobileDetailDialog,
+  .workspaceDialog,
+  .todoViewerDialog,
+  .fileViewerDialog,
+  .harnessDialog {
+    width: calc(100vw - 12px);
+    max-width: calc(100vw - 12px);
+    max-height: calc(var(--appH, 100dvh) - 12px);
+    border-radius: 22px;
+  }
+
+  .workspaceDialog,
+  .todoViewerDialog,
+  .fileViewerDialog,
+  .harnessDialog {
+    min-height: min(70vh, calc(var(--appH, 100dvh) - 12px));
+  }
+
+  .workspaceDialogBody,
+  .todoViewerDialogFrame {
+    min-height: 0;
   }
 
   .messageRow {


### PR DESCRIPTION
## What
- add a dedicated mobile shell with bottom navigation for Sessions, Chat, and Tools
- move mobile-primary actions out of the desktop overflow/sheet model
- tighten mobile detail surfaces for workspace, files, todo, and harness flows
- improve compact viewport behavior for composer focus, keyboard resize, and mobile file viewing

## Validation
- npm test
- npm run build