### PR TITLE
Add mobile read mode and compact chat composer

### DIFF
--- a/web/src/app/AppShell.test.tsx
+++ b/web/src/app/AppShell.test.tsx
@@ -318,6 +318,7 @@ describe("AppShell", () => {
       renderAppShell({ activeSessionId: null, diagnostics: null });
       expect(getRoot().querySelector('[data-testid="mobile-shell"]')).not.toBeNull();
       expect(findButtonByText("Sessions")).not.toBeNull();
+      expect(findButtonByText("Read")).not.toBeNull();
       expect(findButtonByText("Chat")).not.toBeNull();
       expect(findButtonByText("Tools")).not.toBeNull();
       expect(findButtonByAriaLabel("Conversation tools")).toBeNull();
@@ -341,6 +342,37 @@ describe("AppShell", () => {
     expect(findButtonByAriaLabel("Interrupt (Esc)")?.querySelector("svg")).not.toBeNull();
   });
 
+  it("defaults to read mode on narrow viewports when a session is active", async () => {
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(max-width: 880px)",
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn().mockReturnValue(false),
+      })),
+    });
+
+    try {
+      renderAppShell({ diagnostics: { status: "ok" } });
+      await flush();
+
+      expect(getRoot().textContent).toContain("Read");
+      expect(findButtonByAriaLabel("Conversation tools")).toBeNull();
+      expect(getRoot().querySelector("[data-testid='composer-card']")).toBeNull();
+    } finally {
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        value: originalMatchMedia,
+      });
+    }
+  });
+
   it("switches to the tools page on narrow viewports", async () => {
     const originalMatchMedia = window.matchMedia;
     Object.defineProperty(window, "matchMedia", {
@@ -361,7 +393,7 @@ describe("AppShell", () => {
       renderAppShell({ diagnostics: { status: "ok" } });
       await flush();
 
-      expect(getRoot().textContent).toContain("Active session");
+      expect(getRoot().textContent).toContain("Read");
       expect(findButtonByAriaLabel("Conversation tools")).toBeNull();
 
       act(() => {
@@ -445,6 +477,44 @@ describe("AppShell", () => {
     }
   });
 
+  it("switches to compact chat mode on narrow viewports without queue or attach actions", async () => {
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(max-width: 880px)",
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn().mockReturnValue(false),
+      })),
+    });
+
+    try {
+      renderAppShell({ diagnostics: { status: "ok" } });
+      await flush();
+
+      act(() => {
+        findButtonByText("Chat")?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      });
+      await flush();
+
+      expect(getRoot().querySelector("[data-testid='composer-card']")).not.toBeNull();
+      expect(getRoot().textContent).toContain("Chat");
+      expect(findButtonByText("Queue")).toBeUndefined();
+      expect(findButtonByAriaLabel("Attach file")).toBeNull();
+      expect(findButtonByAriaLabel("Cancel current loop")).not.toBeNull();
+    } finally {
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        value: originalMatchMedia,
+      });
+    }
+  });
+
   it("switches back to the sessions page from bottom navigation on narrow viewports", async () => {
     const originalMatchMedia = window.matchMedia;
     Object.defineProperty(window, "matchMedia", {
@@ -465,7 +535,7 @@ describe("AppShell", () => {
       renderAppShell({ diagnostics: { status: "ok" } });
       await flush();
 
-      expect(getRoot().textContent).toContain("Active session");
+      expect(getRoot().textContent).toContain("Read");
       act(() => {
         findButtonByText("Sessions")?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
       });

--- a/web/src/app/app-shell/MobileShell.tsx
+++ b/web/src/app/app-shell/MobileShell.tsx
@@ -5,7 +5,7 @@ import { Composer } from "@/components/composer/Composer";
 import { ConversationPane } from "@/components/conversation/ConversationPane";
 import { FileIcon, HarnessIcon, StopIcon, TodoListIcon, WorkspaceIcon } from "./icons";
 
-export type MobileShellTab = "sessions" | "chat" | "tools";
+export type MobileShellTab = "sessions" | "read" | "chat" | "tools";
 
 interface MobileShellProps {
   activeSessionId: string | null;
@@ -145,11 +145,13 @@ export function MobileShell({
   onToggleAnnouncements,
   onToggleNotifications,
 }: MobileShellProps) {
-  const [tab, setTab] = useState<MobileShellTab>(activeSessionId ? "chat" : "sessions");
+  const [tab, setTab] = useState<MobileShellTab>(activeSessionId ? "read" : "sessions");
 
   useEffect(() => {
     if (activeSessionId) {
-      setTab("chat");
+      setTab("read");
+    } else {
+      setTab("sessions");
     }
     blurActiveInteractiveElement();
   }, [activeSessionId]);
@@ -168,11 +170,34 @@ export function MobileShell({
             <SessionsPane onNewSession={onNewSession} />
           </div>
         ) : null}
+        {tab === "read" ? (
+          <section className="mobilePane mobileReadPane">
+            <header className="mobileReadHeader">
+              <div className="mobileChatHeading">
+                <p className="mobileSectionEyebrow">Read</p>
+                <h1 className="mobileChatTitle">{activeSessionId ? activeTitle : "No session selected"}</h1>
+              </div>
+              <div className="mobileReadHeaderActions">
+                {canInterrupt ? (
+                  <Button type="button" variant="outline" size="sm" className="mobileInterruptButton" onClick={onInterrupt}>
+                    <StopIcon />
+                    <span>Interrupt</span>
+                  </Button>
+                ) : null}
+                <Button type="button" variant="outline" size="sm" className="mobileReplyButton" onClick={() => setTab("chat")}>Reply</Button>
+              </div>
+            </header>
+            <ConversationPane
+              key={activeSessionId || "no-session"}
+              onOpenFilePath={(path, line) => onOpenFilePath(path, line ?? null)}
+            />
+          </section>
+        ) : null}
         {tab === "chat" ? (
           <section className="mobilePane mobileChatPane">
             <header className="mobileChatHeader">
               <div className="mobileChatHeading">
-                <p className="mobileSectionEyebrow">Active session</p>
+                <p className="mobileSectionEyebrow">Chat</p>
                 <h1 className="mobileChatTitle">{activeSessionId ? activeTitle : "No session selected"}</h1>
               </div>
               {canInterrupt ? (
@@ -186,7 +211,7 @@ export function MobileShell({
               key={activeSessionId || "no-session"}
               onOpenFilePath={(path, line) => onOpenFilePath(path, line ?? null)}
             />
-            <Composer />
+            <Composer compactMobile />
           </section>
         ) : null}
         {tab === "tools" ? (
@@ -217,6 +242,14 @@ export function MobileShell({
           onClick={() => setTab("sessions")}
         >
           Sessions
+        </Button>
+        <Button
+          type="button"
+          variant={tab === "read" ? "default" : "outline"}
+          className="mobileBottomNavButton"
+          onClick={() => setTab("read")}
+        >
+          Read
         </Button>
         <Button
           type="button"

--- a/web/src/components/composer/Composer.test.tsx
+++ b/web/src/components/composer/Composer.test.tsx
@@ -42,6 +42,7 @@ interface RenderComposerOptions {
   draft?: string;
   submitResult?: unknown;
   composerStore?: any;
+  compactMobile?: boolean;
 }
 
 let root: HTMLDivElement | null = null;
@@ -112,6 +113,7 @@ function renderComposer(options: RenderComposerOptions = {}) {
     draft = "Hello",
     submitResult,
     composerStore: providedComposerStore,
+    compactMobile = false,
   } = options;
   const submit = vi.fn().mockResolvedValue(submitResult);
   const liveSessionStore = createStore(
@@ -186,7 +188,7 @@ function renderComposer(options: RenderComposerOptions = {}) {
         liveSessionStore={liveSessionStore as any}
         sessionUiStore={sessionUiStore as any}
       >
-        <Composer />
+        <Composer compactMobile={compactMobile} />
       </AppProviders>,
       root!,
     );
@@ -576,6 +578,24 @@ describe("Composer", () => {
     expect(controlsRow?.querySelector(".composerAttachButton")).not.toBeNull();
     expect(controlsRow?.querySelector(".composerQueueButton")).not.toBeNull();
     expect(controlsRow?.querySelector(".sendButton")).not.toBeNull();
+  });
+
+  it("renders compact mobile controls with horizontal metadata and no queue or attach buttons", () => {
+    renderComposer({
+      compactMobile: true,
+      items: [{ session_id: "sess-1", agent_backend: "pi", busy: true }],
+      liveContextUsageBySessionId: {
+        "sess-1": { used_tokens: 82000, total_tokens: 200000, percent_used: 41 },
+      },
+    });
+    const composerRoot = getRoot();
+
+    expect(composerRoot.querySelector(".composerControlsColumn.compactMobile")).not.toBeNull();
+    expect(composerRoot.querySelector(".composerMetaRow.compactMobile")).not.toBeNull();
+    expect(composerRoot.querySelector(".composerAttachButton")).toBeNull();
+    expect(composerRoot.querySelector(".composerQueueButton")).toBeNull();
+    expect(composerRoot.querySelector(".composerInterruptButton")).not.toBeNull();
+    expect(composerRoot.querySelector(".sendButton")).not.toBeNull();
   });
 
   it("starts with two rows on mobile and caps textarea growth after the mobile max height", async () => {

--- a/web/src/components/composer/Composer.tsx
+++ b/web/src/components/composer/Composer.tsx
@@ -274,7 +274,11 @@ async function toJpegBlob(file: File, options: { maxDim: number; quality: number
   }
 }
 
-export function Composer() {
+interface ComposerProps {
+  compactMobile?: boolean;
+}
+
+export function Composer({ compactMobile = false }: ComposerProps = {}) {
   const { activeSessionId, items } = useSessionsStore();
   const { bySessionId = {} } = useMessagesStore() as {
     bySessionId?: Record<string, MessageEvent[]>;
@@ -882,36 +886,44 @@ export function Composer() {
                 </div>
               ) : null}
             </div>
-            <div className="composerControlsColumn">
-              {composerTurnElapsedLabel ? <div className="composerTurnTiming">{composerTurnElapsedLabel}</div> : null}
-              {composerContextUsageLabel ? <div className="composerContextUsage">{composerContextUsageLabel}</div> : null}
-              <div className="composerControlsRow">
+            <div className={cn("composerControlsColumn", compactMobile && "compactMobile") }>
+              {composerTurnElapsedLabel || composerContextUsageLabel ? (
+                <div className={cn("composerMetaRow", compactMobile && "compactMobile")}>
+                  {composerTurnElapsedLabel ? <div className="composerTurnTiming">{composerTurnElapsedLabel}</div> : null}
+                  {composerContextUsageLabel ? <div className="composerContextUsage">{composerContextUsageLabel}</div> : null}
+                </div>
+              ) : null}
+              <div className={cn("composerControlsRow", compactMobile && "compactMobile")}>
                 <input ref={fileInputRef} type="file" hidden tabIndex={-1} onChange={handleAttachChange} />
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon"
-                  className="composerAttachButton"
-                  aria-label="Attach file"
-                  title={attachButtonTitle}
-                  disabled={!attachmentsSupported || attachmentUploading || sending}
-                  onClick={handleAttachClick}
-                >
-                  <span className="buttonGlyph">📎</span>
-                  {activeAttachmentCount > 0 ? <span className="composerAttachBadge">{activeAttachmentCount}</span> : null}
-                  <span className="visuallyHidden">Attach file</span>
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="composerQueueButton"
-                  aria-label="Queued messages"
-                  disabled={sending || !draft.trim()}
-                  onClick={queueCurrentDraft}
-                >
-                  Queue
-                </Button>
+                {!compactMobile ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="composerAttachButton"
+                    aria-label="Attach file"
+                    title={attachButtonTitle}
+                    disabled={!attachmentsSupported || attachmentUploading || sending}
+                    onClick={handleAttachClick}
+                  >
+                    <span className="buttonGlyph">📎</span>
+                    {activeAttachmentCount > 0 ? <span className="composerAttachBadge">{activeAttachmentCount}</span> : null}
+                    <span className="visuallyHidden">Attach file</span>
+                  </Button>
+                ) : null}
+                {!compactMobile ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="composerQueueButton"
+                    aria-label="Queued messages"
+                    disabled={sending || !draft.trim()}
+                    onClick={queueCurrentDraft}
+                  >
+                    Queue
+                  </Button>
+                ) : null}
                 {activeSessionBusy ? (
                   <Button
                     type="button"

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -424,12 +424,14 @@ select {
   flex-direction: column;
 }
 
-.mobileChatPane {
+.mobileChatPane,
+.mobileReadPane {
   min-height: 0;
   background: color-mix(in srgb, var(--panel) 97%, white);
 }
 
 .mobileChatHeader,
+.mobileReadHeader,
 .mobileSectionHeader {
   display: flex;
   align-items: flex-start;
@@ -467,6 +469,17 @@ select {
 }
 
 .mobileInterruptButton {
+  flex: 0 0 auto;
+}
+
+.mobileReadHeaderActions {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex: 0 0 auto;
+}
+
+.mobileReplyButton {
   flex: 0 0 auto;
 }
 
@@ -551,8 +564,8 @@ select {
 
 .mobileBottomNav {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.6rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.45rem;
   padding: 0.75rem 0.9rem calc(0.75rem + env(safe-area-inset-bottom));
   border-top: 1px solid color-mix(in srgb, var(--legacy-border) 78%, white);
   background: color-mix(in srgb, var(--panel) 94%, white);
@@ -561,6 +574,7 @@ select {
 .mobileBottomNavButton {
   min-height: 2.9rem;
   border-radius: 999px;
+  padding-inline: 0.45rem;
 }
 
 .conversationToolbar {
@@ -2083,6 +2097,26 @@ select {
   min-width: fit-content;
 }
 
+.composerMetaRow {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.composerControlsColumn.compactMobile {
+  min-width: 0;
+  width: 100%;
+  align-items: stretch;
+}
+
+.composerMetaRow.compactMobile {
+  justify-content: space-between;
+  gap: 0.5rem;
+  flex-wrap: nowrap;
+}
+
 .composerControlsRow {
   flex: 0 0 auto;
   display: flex;
@@ -2842,6 +2876,10 @@ select {
     padding: 0 0.9rem;
   }
 
+  .mobileReadHeaderActions {
+    gap: 0.35rem;
+  }
+
   .mobileToggleStack {
     padding: 0 0.9rem;
   }
@@ -3032,6 +3070,19 @@ select {
     gap: 8px;
   }
 
+  .composerMetaRow {
+    width: 100%;
+  }
+
+  .composerControlsColumn.compactMobile {
+    gap: 7px;
+  }
+
+  .composerMetaRow.compactMobile {
+    gap: 0.4rem;
+    justify-content: space-between;
+  }
+
   .composerInputWrap {
     width: 100%;
     min-height: 56px;
@@ -3051,6 +3102,20 @@ select {
   .composerQueueButton {
     min-width: fit-content;
     margin-left: auto;
+  }
+
+  .composerControlsRow.compactMobile {
+    flex-wrap: nowrap;
+    justify-content: flex-end;
+  }
+
+  .composerControlsRow.compactMobile .composerInterruptButton {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .composerControlsRow.compactMobile .sendButton {
+    flex: 0 0 auto;
   }
 
   .composerTextarea {


### PR DESCRIPTION
## What
- add a dedicated `Read` tab to the mobile bottom navigation and make mobile sessions land in read mode by default
- keep `Chat` as a reply-focused mode with a tighter mobile composer
- remove mobile queue and attachment controls so the send path stays on one row
- render turn timing and context usage in one horizontal mobile metadata row

## Validation
- npm test
- npm run build