### PR TITLE
feat: add SSE invalidation updates

### DIFF
--- a/codoxear/events/hub.py
+++ b/codoxear/events/hub.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class EventPollResult:
+    events: list[dict[str, Any]]
+    cursor_expired: bool
+    closed: bool
+    latest_seq: int
+
+
+class EventHub:
+    def __init__(self, *, max_events: int = 512) -> None:
+        self._max_events = max(32, int(max_events))
+        self._events: deque[dict[str, Any]] = deque()
+        self._cond = threading.Condition()
+        self._next_seq = 1
+        self._closed = False
+        self._last_emit_ts_by_key: dict[tuple[str, str], float] = {}
+
+    def close(self) -> None:
+        with self._cond:
+            self._closed = True
+            self._cond.notify_all()
+
+    def latest_seq(self) -> int:
+        with self._cond:
+            if not self._events:
+                return max(0, self._next_seq - 1)
+            return int(self._events[-1].get("seq") or 0)
+
+    def publish(self, event: dict[str, Any]) -> dict[str, Any] | None:
+        payload = dict(event)
+        event_type = str(payload.get("type") or "").strip()
+        if not event_type:
+            raise ValueError("event type required")
+        now_ts = float(payload.get("ts") or time.time())
+        coalesce_ms = int(payload.pop("_coalesce_ms", 0) or 0)
+        raw_key = payload.pop("_coalesce_key", None)
+        if isinstance(raw_key, tuple) and len(raw_key) == 2:
+            coalesce_key = (str(raw_key[0]), str(raw_key[1]))
+        else:
+            session_key = str(payload.get("session_id") or "")
+            coalesce_key = (event_type, session_key)
+        with self._cond:
+            if self._closed:
+                return None
+            if coalesce_ms > 0:
+                last_emit_ts = self._last_emit_ts_by_key.get(coalesce_key)
+                if last_emit_ts is not None and ((now_ts - last_emit_ts) * 1000.0) < float(coalesce_ms):
+                    return None
+            stamped = dict(payload)
+            stamped["seq"] = self._next_seq
+            self._next_seq += 1
+            stamped["type"] = event_type
+            stamped["ts"] = now_ts
+            self._events.append(stamped)
+            while len(self._events) > self._max_events:
+                self._events.popleft()
+            if coalesce_ms > 0:
+                self._last_emit_ts_by_key[coalesce_key] = now_ts
+            self._cond.notify_all()
+            return stamped
+
+    def poll(self, after_seq: int, *, timeout_s: float) -> EventPollResult:
+        target_seq = max(0, int(after_seq))
+        deadline = time.monotonic() + max(0.0, float(timeout_s))
+        with self._cond:
+            while True:
+                if self._closed:
+                    return EventPollResult(events=[], cursor_expired=False, closed=True, latest_seq=self._latest_seq_locked())
+                if self._events:
+                    first_seq = int(self._events[0].get("seq") or 0)
+                    latest_seq = int(self._events[-1].get("seq") or 0)
+                    if target_seq < (first_seq - 1):
+                        return EventPollResult(events=[], cursor_expired=True, closed=False, latest_seq=latest_seq)
+                    if target_seq < latest_seq:
+                        return EventPollResult(
+                            events=[dict(item) for item in self._events if int(item.get("seq") or 0) > target_seq],
+                            cursor_expired=False,
+                            closed=False,
+                            latest_seq=latest_seq,
+                        )
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return EventPollResult(events=[], cursor_expired=False, closed=False, latest_seq=self._latest_seq_locked())
+                self._cond.wait(timeout=remaining)
+
+    def _latest_seq_locked(self) -> int:
+        if not self._events:
+            return max(0, self._next_seq - 1)
+        return int(self._events[-1].get("seq") or 0)

--- a/codoxear/http/routes/events.py
+++ b/codoxear/http/routes/events.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import socket
+import time
+import urllib.parse
+from typing import Any
+
+_SERVER = None
+SSE_HEARTBEAT_SECONDS = 15.0
+SSE_RETRY_MS = 3000
+
+
+def bind_server_runtime(runtime: Any) -> None:
+    global _SERVER
+    _SERVER = runtime
+
+
+
+def _sv() -> Any:
+    if _SERVER is None:
+        raise RuntimeError("server runtime not bound")
+    return _SERVER
+
+
+
+def _cursor_from_request(handler: Any, query: dict[str, list[str]]) -> int:
+    header_value = ""
+    headers = getattr(handler, "headers", None)
+    if headers is not None:
+        header_value = str(headers.get("Last-Event-ID") or "").strip()
+    cursor_value = str((query.get("cursor") or [header_value or "0"])[0] or header_value or "0").strip()
+    try:
+        return max(0, int(cursor_value or "0"))
+    except ValueError:
+        return 0
+
+
+
+def _write_sse_event(handler: Any, event: dict[str, Any]) -> None:
+    payload = json.dumps(event, ensure_ascii=True, separators=(",", ":"))
+    data = (
+        f"id: {int(event.get('seq') or 0)}\n"
+        f"event: {str(event.get('type') or 'message')}\n"
+        f"data: {payload}\n\n"
+    ).encode("utf-8")
+    handler.wfile.write(data)
+    handler.wfile.flush()
+
+
+
+def _write_sse_comment(handler: Any, text: str) -> None:
+    handler.wfile.write(f": {text}\n\n".encode("utf-8"))
+    handler.wfile.flush()
+
+
+
+def handle_get(handler: Any, path: str, u: Any) -> bool:
+    sv = _sv()
+    if path != "/api/events":
+        return False
+    if not sv._require_auth(handler):
+        handler._unauthorized()
+        return True
+
+    query = urllib.parse.parse_qs(u.query)
+    after_seq = _cursor_from_request(handler, query)
+    handler.send_response(200)
+    handler.send_header("Content-Type", "text/event-stream")
+    handler.send_header("Cache-Control", "no-store")
+    handler.send_header("Connection", "keep-alive")
+    handler.send_header("X-Accel-Buffering", "no")
+    handler.end_headers()
+
+    try:
+        handler.wfile.write(f"retry: {SSE_RETRY_MS}\n\n".encode("utf-8"))
+        handler.wfile.flush()
+        while True:
+            result = sv.EVENT_HUB.poll(after_seq, timeout_s=SSE_HEARTBEAT_SECONDS)
+            if result.closed:
+                return True
+            if result.cursor_expired:
+                resync_event = {
+                    "seq": result.latest_seq,
+                    "type": "stream.resync",
+                    "ts": time.time(),
+                }
+                _write_sse_event(handler, resync_event)
+                after_seq = int(result.latest_seq)
+                continue
+            if result.events:
+                for event in result.events:
+                    _write_sse_event(handler, event)
+                    after_seq = max(after_seq, int(event.get("seq") or 0))
+                continue
+            _write_sse_comment(handler, "heartbeat")
+    except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, socket.timeout, ValueError, OSError):
+        return True

--- a/codoxear/http/routes/sessions_write.py
+++ b/codoxear/http/routes/sessions_write.py
@@ -95,6 +95,7 @@ def handle_post(handler: Any, path: str, _u: Any) -> bool:
         response_payload = {"ok": True, **res}
         if alias:
             response_payload["alias"] = alias
+        sv._publish_sessions_invalidate(reason="session_created")
         sv._json_response(handler, 200, response_payload)
         return True
     session_id = sv._match_session_route(path, "delete")
@@ -107,6 +108,7 @@ def handle_post(handler: Any, path: str, _u: Any) -> bool:
         if not ok:
             sv._json_response(handler, 404, {"error": "unknown session"})
             return True
+        sv._publish_sessions_invalidate(reason="session_deleted")
         sv._json_response(handler, 200, {"ok": True})
         return True
     if path.startswith("/api/sessions/") and path.endswith("/edit"):
@@ -245,6 +247,13 @@ def handle_post(handler: Any, path: str, _u: Any) -> bool:
         except ValueError as e:
             sv._json_response(handler, 502, {"error": str(e)})
             return True
+        durable_session_id = sv.MANAGER._durable_session_id_for_identifier(session_id) or session_id
+        runtime_id = sv.MANAGER._runtime_session_id_for_identifier(session_id)
+        sv._publish_session_workspace_invalidate(
+            durable_session_id,
+            runtime_id=runtime_id,
+            reason="ui_response",
+        )
         sv._json_response(handler, 200, {"ok": True})
         return True
     if path.startswith("/api/sessions/") and path.endswith("/enqueue"):
@@ -399,6 +408,13 @@ def handle_post(handler: Any, path: str, _u: Any) -> bool:
         except ValueError as e:
             sv._json_response(handler, 502, {"error": str(e)})
             return True
+        durable_session_id = sv.MANAGER._durable_session_id_for_identifier(session_id) or session_id
+        runtime_id = sv.MANAGER._runtime_session_id_for_identifier(session_id)
+        sv._publish_session_live_invalidate(
+            durable_session_id,
+            runtime_id=runtime_id,
+            reason="interrupt",
+        )
         sv._json_response(handler, 200, {"ok": True, "broker": resp})
         return True
     return False

--- a/codoxear/server.py
+++ b/codoxear/server.py
@@ -44,8 +44,10 @@ from .agent_backend import (
     infer_agent_backend_from_log_path,
     normalize_agent_backend,
 )
+from .events.hub import EventHub
 from .http.routes import assets as _http_assets_routes
 from .http.routes import auth as _http_auth_routes
+from .http.routes import events as _http_events_routes
 from .http.routes import files as _http_file_routes
 from .http.routes import notifications as _http_notification_routes
 from .http.routes import sessions_read as _http_session_read_routes
@@ -84,6 +86,7 @@ SessionStateKey = SessionRef | str
 for _seam_module in (
     _http_assets_routes,
     _http_auth_routes,
+    _http_events_routes,
     _http_file_routes,
     _http_notification_routes,
     _http_session_read_routes,
@@ -97,6 +100,132 @@ for _seam_module in (
 
 
 LOG = logging.getLogger(__name__)
+EVENT_HUB = EventHub(max_events=1024)
+
+
+def _publish_invalidate_event(
+    event_type: str,
+    *,
+    session_id: str | None = None,
+    runtime_id: str | None = None,
+    reason: str,
+    hints: dict[str, Any] | None = None,
+    coalesce_ms: int = 300,
+) -> dict[str, Any] | None:
+    payload: dict[str, Any] = {
+        "type": event_type,
+        "reason": str(reason).strip() or "update",
+        "_coalesce_ms": int(coalesce_ms),
+        "_coalesce_key": (str(event_type), str(session_id or "")),
+    }
+    clean_session_id = _clean_optional_text(session_id)
+    clean_runtime_id = _clean_optional_text(runtime_id)
+    if clean_session_id is not None:
+        payload["session_id"] = clean_session_id
+    if clean_runtime_id is not None:
+        payload["runtime_id"] = clean_runtime_id
+    if isinstance(hints, dict) and hints:
+        payload["hints"] = dict(hints)
+    return EVENT_HUB.publish(payload)
+
+
+
+def _publish_sessions_invalidate(*, reason: str, coalesce_ms: int = 500) -> dict[str, Any] | None:
+    return _publish_invalidate_event(
+        "sessions.invalidate",
+        reason=reason,
+        coalesce_ms=coalesce_ms,
+    )
+
+
+
+def _publish_session_live_invalidate(
+    session_id: str,
+    *,
+    runtime_id: str | None = None,
+    reason: str,
+    hints: dict[str, Any] | None = None,
+    coalesce_ms: int = 300,
+) -> dict[str, Any] | None:
+    return _publish_invalidate_event(
+        "session.live.invalidate",
+        session_id=session_id,
+        runtime_id=runtime_id,
+        reason=reason,
+        hints=hints,
+        coalesce_ms=coalesce_ms,
+    )
+
+
+
+def _publish_session_workspace_invalidate(
+    session_id: str,
+    *,
+    runtime_id: str | None = None,
+    reason: str,
+    coalesce_ms: int = 300,
+) -> dict[str, Any] | None:
+    return _publish_invalidate_event(
+        "session.workspace.invalidate",
+        session_id=session_id,
+        runtime_id=runtime_id,
+        reason=reason,
+        coalesce_ms=coalesce_ms,
+    )
+
+
+
+def _publish_session_transport_invalidate(
+    session_id: str,
+    *,
+    runtime_id: str | None = None,
+    reason: str,
+    coalesce_ms: int = 300,
+) -> dict[str, Any] | None:
+    return _publish_invalidate_event(
+        "session.transport.invalidate",
+        session_id=session_id,
+        runtime_id=runtime_id,
+        reason=reason,
+        coalesce_ms=coalesce_ms,
+    )
+
+
+
+def _publish_notifications_invalidate(*, reason: str, coalesce_ms: int = 500) -> dict[str, Any] | None:
+    return _publish_invalidate_event(
+        "notifications.invalidate",
+        reason=reason,
+        coalesce_ms=coalesce_ms,
+    )
+
+
+
+def _publish_attention_invalidate(
+    *,
+    reason: str,
+    session_id: str | None = None,
+    coalesce_ms: int = 500,
+) -> dict[str, Any] | None:
+    return _publish_invalidate_event(
+        "attention.invalidate",
+        session_id=session_id,
+        reason=reason,
+        coalesce_ms=coalesce_ms,
+    )
+
+
+
+def _voice_push_publish_callback(event: dict[str, Any]) -> None:
+    _publish_invalidate_event(
+        str(event.get("type") or "notifications.invalidate"),
+        session_id=_clean_optional_text(event.get("session_id")),
+        runtime_id=_clean_optional_text(event.get("runtime_id")),
+        reason=str(event.get("reason") or "update"),
+        hints=event.get("hints") if isinstance(event.get("hints"), dict) else None,
+        coalesce_ms=int(event.get("coalesce_ms") or 500),
+    )
+
 
 
 def _load_env_file(path: Path) -> dict[str, str]:
@@ -4027,6 +4156,7 @@ class SessionManager:
             delivery_ledger_path=DELIVERY_LEDGER_PATH,
             vapid_private_key_path=VAPID_PRIVATE_KEY_PATH,
             page_state_db=self._page_state_db,
+            publish_callback=_voice_push_publish_callback,
         )
         self._discover_existing(force=True, skip_invalid_sidecars=True)
         self._refresh_durable_session_catalog(force=True)
@@ -4053,6 +4183,7 @@ class SessionManager:
 
     def stop(self) -> None:
         self._stop.set()
+        EVENT_HUB.close()
 
     def _page_state_ref_for_session(self, session: Session) -> SessionRef | None:
         durable_id = _clean_optional_text(session.thread_id) or _clean_optional_text(session.session_id)
@@ -4120,7 +4251,8 @@ class SessionManager:
             rows = rows_by_session[key]
             if len(rows) > 64:
                 rows_by_session[key] = rows[-64:]
-            return stamped
+        _publish_session_live_invalidate(key, reason="bridge_event")
+        return stamped
 
     def _bridge_events_since(self, durable_session_id: str, offset: int = 0) -> tuple[list[dict[str, Any]], int]:
         key = _clean_optional_text(durable_session_id)
@@ -4151,13 +4283,32 @@ class SessionManager:
         error: str | None = None,
         checked_ts: float | None = None,
     ) -> None:
+        publish = False
+        durable_session_id: str | None = None
         with self._lock:
             session = self._sessions.get(runtime_id)
             if session is None:
                 return
+            next_error = _clean_optional_text(error)
+            publish = (
+                session.bridge_transport_state != state
+                or session.bridge_transport_error != next_error
+            )
             session.bridge_transport_state = state
-            session.bridge_transport_error = _clean_optional_text(error)
+            session.bridge_transport_error = next_error
             session.bridge_transport_checked_ts = float(checked_ts if checked_ts is not None else time.time())
+            durable_session_id = self._durable_session_id_for_session(session)
+        if publish and durable_session_id is not None:
+            _publish_session_transport_invalidate(
+                durable_session_id,
+                runtime_id=runtime_id,
+                reason="transport_state",
+            )
+            _publish_session_live_invalidate(
+                durable_session_id,
+                runtime_id=runtime_id,
+                reason="transport_state",
+            )
 
     def _probe_bridge_transport(self, session_id: str, *, force_rpc: bool = False) -> tuple[str, str | None]:
         runtime_id = self._runtime_session_id_for_identifier(session_id)
@@ -4477,9 +4628,11 @@ class SessionManager:
                     pending_startup=False,
                 )
             )
+            _publish_sessions_invalidate(reason="session_created")
         except Exception:
             self._delete_durable_session_record(ref)
             self._clear_deleted_session_state(durable_session_id)
+            _publish_sessions_invalidate(reason="session_removed")
 
     def _persist_session_ui_state(self) -> None:
         self._sidebar_state_facade().persist_session_ui_state()
@@ -4824,13 +4977,16 @@ class SessionManager:
         )
 
     def alias_set(self, session_id: str, name: str) -> str:
-        return self._sidebar_state_facade().alias_set(session_id, name)
+        alias = self._sidebar_state_facade().alias_set(session_id, name)
+        _publish_sessions_invalidate(reason="alias_changed")
+        return alias
 
     def alias_get(self, session_id: str) -> str:
         return self._sidebar_state_facade().alias_get(session_id)
 
     def alias_clear(self, session_id: str) -> None:
         self._sidebar_state_facade().alias_clear(session_id)
+        _publish_sessions_invalidate(reason="alias_cleared")
 
     def sidebar_meta_get(self, session_id: str) -> dict[str, Any]:
         return self._sidebar_state_facade().sidebar_meta_get(session_id)
@@ -4843,15 +4999,19 @@ class SessionManager:
         snooze_until: Any,
         dependency_session_id: Any,
     ) -> dict[str, Any]:
-        return self._sidebar_state_facade().sidebar_meta_set(
+        payload = self._sidebar_state_facade().sidebar_meta_set(
             session_id,
             priority_offset=priority_offset,
             snooze_until=snooze_until,
             dependency_session_id=dependency_session_id,
         )
+        _publish_sessions_invalidate(reason="sidebar_meta_changed")
+        return payload
 
     def focus_set(self, session_id: str, focused: Any) -> bool:
-        return self._sidebar_state_facade().focus_set(session_id, focused)
+        value = self._sidebar_state_facade().focus_set(session_id, focused)
+        _publish_sessions_invalidate(reason="focus_changed")
+        return value
 
     def edit_session(
         self,
@@ -4862,13 +5022,15 @@ class SessionManager:
         snooze_until: Any,
         dependency_session_id: Any,
     ) -> tuple[str, dict[str, Any]]:
-        return self._sidebar_state_facade().edit_session(
+        payload = self._sidebar_state_facade().edit_session(
             session_id,
             name=name,
             priority_offset=priority_offset,
             snooze_until=snooze_until,
             dependency_session_id=dependency_session_id,
         )
+        _publish_sessions_invalidate(reason="session_edited")
+        return payload
 
     def _clear_deleted_session_state(self, session_id: str) -> None:
         changed_sidebar = False
@@ -5366,6 +5528,12 @@ class SessionManager:
         touched_ts: float | None = None
         ref = self._page_state_ref_for_session_id(session_id)
         runtime_id = self._runtime_session_id_for_identifier(session_id)
+        durable_session_id = _clean_optional_text(session_id)
+        with self._lock:
+            if runtime_id is not None:
+                s0 = self._sessions.get(runtime_id)
+                if s0 is not None:
+                    durable_session_id = self._durable_session_id_for_session(s0)
         if ref is None:
             raise KeyError("unknown session")
         with self._lock:
@@ -5386,6 +5554,17 @@ class SessionManager:
                 s.pi_idle_activity_ts = None
                 s.pi_busy_activity_floor = touched_ts
         self._save_queues()
+        if durable_session_id is not None:
+            _publish_session_workspace_invalidate(
+                durable_session_id,
+                runtime_id=runtime_id,
+                reason="queue_changed",
+            )
+            _publish_session_live_invalidate(
+                durable_session_id,
+                runtime_id=runtime_id,
+                reason="queue_changed",
+            )
         return {"queued": True, "queue_len": int(ql)}
 
     def _queue_delete_local(self, session_id: str, index: int) -> dict[str, Any]:
@@ -5394,8 +5573,10 @@ class SessionManager:
         if ref is None or runtime_id is None:
             raise KeyError("unknown session")
         with self._lock:
-            if runtime_id not in self._sessions:
+            session = self._sessions.get(runtime_id)
+            if session is None:
                 raise KeyError("unknown session")
+            durable_session_id = self._durable_session_id_for_session(session)
             q = self._queues.get(runtime_id)
             if not isinstance(q, list):
                 q = []
@@ -5408,6 +5589,16 @@ class SessionManager:
                 self._queues.pop(runtime_id, None)
                 self._queues.pop(ref, None)
         self._save_queues()
+        _publish_session_workspace_invalidate(
+            durable_session_id,
+            runtime_id=runtime_id,
+            reason="queue_changed",
+        )
+        _publish_session_live_invalidate(
+            durable_session_id,
+            runtime_id=runtime_id,
+            reason="queue_changed",
+        )
         return {"ok": True, "queue_len": int(ql)}
 
     def _queue_update_local(
@@ -5421,8 +5612,10 @@ class SessionManager:
         if ref is None or runtime_id is None:
             raise KeyError("unknown session")
         with self._lock:
-            if runtime_id not in self._sessions:
+            session = self._sessions.get(runtime_id)
+            if session is None:
                 raise KeyError("unknown session")
+            durable_session_id = self._durable_session_id_for_session(session)
             q = self._queues.get(runtime_id)
             if not isinstance(q, list):
                 q = []
@@ -5432,6 +5625,11 @@ class SessionManager:
             q[int(index)] = t
             ql = len(q)
         self._save_queues()
+        _publish_session_workspace_invalidate(
+            durable_session_id,
+            runtime_id=runtime_id,
+            reason="queue_changed",
+        )
         return {"ok": True, "queue_len": int(ql)}
 
     def _files_key_for_session(self, session_id: str) -> tuple[str, SessionRef, "Session"]:
@@ -6254,15 +6452,39 @@ class SessionManager:
             _validated_session_state(resp)
         except Exception as e:
             return False, e
+        publish_sessions = False
+        publish_live = False
+        publish_workspace = False
+        durable_session_id: str | None = None
         with self._lock:
             s2 = self._sessions.get(session_id)
             if s2:
-                s2.busy = _state_busy_value(resp)
-                s2.queue_len = _state_queue_len_value(resp)
-                if "token" in resp:
-                    tok = resp.get("token")
-                    if isinstance(tok, dict):
-                        s2.token = tok
+                next_busy = _state_busy_value(resp)
+                next_queue_len = _state_queue_len_value(resp)
+                next_token = resp.get("token") if isinstance(resp.get("token"), dict) else s2.token
+                durable_session_id = self._durable_session_id_for_session(s2)
+                publish_sessions = s2.busy != next_busy
+                publish_live = publish_sessions or s2.queue_len != next_queue_len or next_token != s2.token
+                publish_workspace = s2.queue_len != next_queue_len
+                s2.busy = next_busy
+                s2.queue_len = next_queue_len
+                if isinstance(resp.get("token"), dict):
+                    s2.token = resp.get("token")
+        if durable_session_id is not None:
+            if publish_sessions:
+                _publish_sessions_invalidate(reason="session_state_changed")
+            if publish_live:
+                _publish_session_live_invalidate(
+                    durable_session_id,
+                    runtime_id=session_id,
+                    reason="session_state_changed",
+                )
+            if publish_workspace:
+                _publish_session_workspace_invalidate(
+                    durable_session_id,
+                    runtime_id=session_id,
+                    reason="session_state_changed",
+                )
         return True, None
 
     def _prune_dead_sessions(self) -> None:
@@ -6283,13 +6505,28 @@ class SessionManager:
             dead.append((sid, s.sock_path))
         if not dead:
             return
+        dead_events: list[tuple[str, str]] = []
         with self._lock:
             for sid, _sock in dead:
-                self._sessions.pop(sid, None)
+                session = self._sessions.pop(sid, None)
+                if session is not None:
+                    dead_events.append((self._durable_session_id_for_session(session), sid))
         for sid, sock in dead:
             self._clear_deleted_session_state(sid)
             _unlink_quiet(sock)
             _unlink_quiet(sock.with_suffix(".json"))
+        _publish_sessions_invalidate(reason="session_removed")
+        for durable_session_id, runtime_id in dead_events:
+            _publish_session_live_invalidate(
+                durable_session_id,
+                runtime_id=runtime_id,
+                reason="session_removed",
+            )
+            _publish_session_workspace_invalidate(
+                durable_session_id,
+                runtime_id=runtime_id,
+                reason="session_removed",
+            )
 
     def _update_meta_counters(self) -> None:
         with self._lock:
@@ -7400,9 +7637,11 @@ class SessionManager:
         self._append_chat_events(
             session_id, new_events, new_off=new_off, latest_token=token_update
         )
+        durable_session_id: str | None = None
         with self._lock:
             s = self._sessions.get(session_id)
             if s:
+                durable_session_id = self._durable_session_id_for_session(s)
                 if isinstance(last_ts, (int, float)):
                     tsf = float(last_ts)
                     s.last_chat_ts = (
@@ -7413,6 +7652,19 @@ class SessionManager:
                 if reasoning_effort is not None:
                     s.reasoning_effort = reasoning_effort
                 s.idle_cache_log_off = -1
+        if durable_session_id is not None and (new_events or token_update is not None or model is not None or reasoning_effort is not None):
+            _publish_session_live_invalidate(
+                durable_session_id,
+                runtime_id=session_id,
+                reason="log_delta",
+            )
+            _publish_session_workspace_invalidate(
+                durable_session_id,
+                runtime_id=session_id,
+                reason="log_delta",
+            )
+            if any(_is_attention_worthy_session_event(event) for event in new_events):
+                _publish_sessions_invalidate(reason="conversation_changed")
 
     def idle_from_log(self, session_id: str) -> bool:
         with self._lock:
@@ -8009,15 +8261,19 @@ class SessionManager:
                     },
                     daemon=True,
                 ).start()
-                return {
+                payload = {
                     "session_id": created_pending_session_id,
                     "runtime_id": None,
                     "backend": "pi",
                     "pending_startup": True,
                 }
+                _publish_sessions_invalidate(reason="session_created")
+                return payload
             _wait_or_raise(proc, label="pi broker", timeout_s=1.5)
             meta = _wait_for_spawned_broker_meta(spawn_nonce)
-            return _spawn_result_from_meta(meta)
+            payload = _spawn_result_from_meta(meta)
+            _publish_sessions_invalidate(reason="session_created")
+            return payload
         if resume_session_id is not None and worktree_branch is not None:
             raise ValueError("worktree_branch cannot be used when resuming a session")
         spawn_cwd = cwd_path
@@ -8246,7 +8502,9 @@ class SessionManager:
         # Prevent zombies when the broker exits.
         threading.Thread(target=proc.wait, daemon=True).start()
         meta = _wait_for_spawned_broker_meta(spawn_nonce)
-        return _spawn_result_from_meta(meta)
+        payload = _spawn_result_from_meta(meta)
+        _publish_sessions_invalidate(reason="session_created")
+        return payload
 
     def delete_session(self, session_id: str) -> bool:
         runtime_id = self._runtime_session_id_for_identifier(session_id)
@@ -8763,6 +9021,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             for route_module in (
                 _http_assets_routes,
                 _http_auth_routes,
+                _http_events_routes,
                 _http_notification_routes,
                 _http_session_read_routes,
                 _http_file_routes,

--- a/codoxear/voice_push.py
+++ b/codoxear/voice_push.py
@@ -14,7 +14,7 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import urlparse
 
 from cryptography.hazmat.primitives import serialization
@@ -718,6 +718,7 @@ class VoicePushCoordinator:
         delivery_ledger_path: Path,
         vapid_private_key_path: Path,
         page_state_db: PageStateDB | None = None,
+        publish_callback: Callable[[dict[str, Any]], None] | None = None,
     ) -> None:
         self._app_dir = Path(app_dir)
         self._stop = stop_event
@@ -726,6 +727,7 @@ class VoicePushCoordinator:
         self._delivery_ledger_path = Path(delivery_ledger_path)
         self._vapid_private_key_path = Path(vapid_private_key_path)
         self._page_state_db = page_state_db
+        self._publish_callback = publish_callback
         self._hls = MergedHLSStream(root_dir=self._app_dir / "audio")
         self._client = OpenAICompatibleClient()
         self._lock = threading.Lock()
@@ -1705,6 +1707,15 @@ class VoicePushCoordinator:
                 raw = {}
         self._voice_settings = _clean_voice_settings(raw)
 
+    def _publish_event(self, event: dict[str, Any]) -> None:
+        callback = self._publish_callback
+        if callback is None:
+            return
+        try:
+            callback(dict(event))
+        except Exception:
+            return
+
     def _save_settings(self) -> None:
         with self._lock:
             payload = dict(self._voice_settings)
@@ -1747,21 +1758,22 @@ class VoicePushCoordinator:
             payload = list(self._subscriptions.values())
         if self._page_state_db is not None:
             self._page_state_db.save_push_subscriptions(payload)
-            return
-        os.makedirs(self._subscriptions_path.parent, exist_ok=True)
-        with tempfile.NamedTemporaryFile(
-            "w",
-            encoding="utf-8",
-            dir=self._subscriptions_path.parent,
-            prefix=self._subscriptions_path.name + ".",
-            suffix=".tmp",
-            delete=False,
-        ) as tmp:
-            tmp.write(
-                json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
-            )
-            tmp_path = Path(tmp.name)
-        os.replace(tmp_path, self._subscriptions_path)
+        else:
+            os.makedirs(self._subscriptions_path.parent, exist_ok=True)
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=self._subscriptions_path.parent,
+                prefix=self._subscriptions_path.name + ".",
+                suffix=".tmp",
+                delete=False,
+            ) as tmp:
+                tmp.write(
+                    json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+                )
+                tmp_path = Path(tmp.name)
+            os.replace(tmp_path, self._subscriptions_path)
+        self._publish_event({"type": "notifications.invalidate", "reason": "subscription_changed"})
 
     def _load_delivery_ledger(self) -> None:
         if self._page_state_db is not None:
@@ -1779,18 +1791,20 @@ class VoicePushCoordinator:
             payload = dict(self._delivery_ledger)
         if self._page_state_db is not None:
             self._page_state_db.save_delivery_ledger(payload)
-            return
-        os.makedirs(self._delivery_ledger_path.parent, exist_ok=True)
-        with tempfile.NamedTemporaryFile(
-            "w",
-            encoding="utf-8",
-            dir=self._delivery_ledger_path.parent,
-            prefix=self._delivery_ledger_path.name + ".",
-            suffix=".tmp",
-            delete=False,
-        ) as tmp:
-            tmp.write(
-                json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
-            )
-            tmp_path = Path(tmp.name)
-        os.replace(tmp_path, self._delivery_ledger_path)
+        else:
+            os.makedirs(self._delivery_ledger_path.parent, exist_ok=True)
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=self._delivery_ledger_path.parent,
+                prefix=self._delivery_ledger_path.name + ".",
+                suffix=".tmp",
+                delete=False,
+            ) as tmp:
+                tmp.write(
+                    json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+                )
+                tmp_path = Path(tmp.name)
+            os.replace(tmp_path, self._delivery_ledger_path)
+        self._publish_event({"type": "notifications.invalidate", "reason": "delivery_ledger_changed"})
+        self._publish_event({"type": "attention.invalidate", "reason": "delivery_ledger_changed"})

--- a/web/src/app/AppShell.test.tsx
+++ b/web/src/app/AppShell.test.tsx
@@ -334,6 +334,35 @@ describe("AppShell", () => {
     expect(liveSessionStore.poll).toHaveBeenCalledWith("sess-2");
   });
 
+  it("does not force a sessions refresh for transport-only invalidations", async () => {
+    const { liveSessionStore, sessionsStore } = renderAppShell({
+      activeSessionId: "sess-1",
+      items: [{ session_id: "sess-1", alias: "Alpha", agent_backend: "pi", busy: true }],
+    });
+
+    await flush();
+    vi.mocked(sessionsStore.refresh).mockClear();
+    vi.mocked(liveSessionStore.poll).mockClear();
+
+    const streamOptions = eventStreamMocks.openAppEventStream.mock.calls[0]?.[0];
+    expect(streamOptions).toBeTruthy();
+    if (!streamOptions?.onEvent) {
+      throw new Error("SSE handler missing");
+    }
+    const onStreamEvent = streamOptions.onEvent;
+    act(() => {
+      onStreamEvent({
+        type: "session.transport.invalidate",
+        session_id: "sess-1",
+        runtime_id: null,
+      });
+    });
+    await flush();
+
+    expect(liveSessionStore.poll).toHaveBeenCalledWith("sess-1");
+    expect(sessionsStore.refresh).not.toHaveBeenCalled();
+  });
+
   it("renders a two-part shell with sessions rail and conversation column", () => {
     renderAppShell({ activeSessionId: null, diagnostics: null });
 

--- a/web/src/app/AppShell.test.tsx
+++ b/web/src/app/AppShell.test.tsx
@@ -5,6 +5,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { AppProviders } from "./providers";
 import { AppShell } from "./AppShell";
 
+const eventStreamMocks = vi.hoisted(() => ({
+  openAppEventStream: vi.fn((_options: { onEvent?: (event: Record<string, unknown>) => void }) => ({
+    close: vi.fn(),
+  })),
+}));
+
+vi.mock("../domains/events/stream", () => ({
+  openAppEventStream: eventStreamMocks.openAppEventStream,
+}));
+
 vi.mock("../lib/api", () => ({
   api: {
     getVoiceSettings: vi.fn().mockResolvedValue({
@@ -267,6 +277,61 @@ describe("AppShell", () => {
     restoreProperty(HTMLMediaElement.prototype, "play", originalMediaPlay);
     restoreProperty(HTMLMediaElement.prototype, "canPlayType", originalMediaCanPlayType);
     vi.clearAllMocks();
+  });
+
+  it("keeps one SSE connection while session state changes", async () => {
+    const { liveSessionStore, sessionsStore } = renderAppShell({
+      activeSessionId: "sess-1",
+      items: [
+        { session_id: "sess-1", alias: "Alpha", agent_backend: "pi", busy: true },
+        { session_id: "sess-2", alias: "Beta", agent_backend: "pi", busy: false },
+      ],
+    });
+
+    await flush();
+    expect(eventStreamMocks.openAppEventStream).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      sessionsStore.setState({
+        ...sessionsStore.getState(),
+        activeSessionId: "sess-2",
+        items: [
+          { session_id: "sess-1", alias: "Alpha", agent_backend: "pi", busy: false },
+          { session_id: "sess-2", alias: "Beta", agent_backend: "pi", busy: true },
+        ],
+      });
+    });
+    await flush();
+
+    act(() => {
+      sessionsStore.setState({
+        ...sessionsStore.getState(),
+        items: [
+          { session_id: "sess-2", alias: "Beta", agent_backend: "pi", busy: true },
+          { session_id: "sess-1", alias: "Alpha", agent_backend: "pi", busy: false },
+        ],
+      });
+    });
+    await flush();
+
+    expect(eventStreamMocks.openAppEventStream).toHaveBeenCalledTimes(1);
+
+    const streamOptions = eventStreamMocks.openAppEventStream.mock.calls[0]?.[0];
+    expect(streamOptions).toBeTruthy();
+    if (!streamOptions?.onEvent) {
+      throw new Error("SSE handler missing");
+    }
+    const onStreamEvent = streamOptions.onEvent;
+    act(() => {
+      onStreamEvent({
+        type: "session.live.invalidate",
+        session_id: "sess-2",
+        runtime_id: null,
+      });
+    });
+    await flush();
+
+    expect(liveSessionStore.poll).toHaveBeenCalledWith("sess-2");
   });
 
   it("renders a two-part shell with sessions rail and conversation column", () => {

--- a/web/src/app/AppShell.tsx
+++ b/web/src/app/AppShell.tsx
@@ -11,6 +11,7 @@ import { AppShellWorkspaceOverlays } from "./app-shell/AppShellWorkspaceOverlays
 import { MobileShell } from "./app-shell/MobileShell";
 import { VoiceSettingsDialog } from "./app-shell/VoiceSettingsDialog";
 import { useAppShellAudio } from "./app-shell/useAppShellAudio";
+import { useAppShellEvents } from "./app-shell/useAppShellEvents";
 import { useAppShellNotifications } from "./app-shell/useAppShellNotifications";
 import { useAppShellSessionEffects } from "./app-shell/useAppShellSessionEffects";
 import { useLiveSessionStore, useLiveSessionStoreApi, useMessagesStore, useSessionUiStore, useSessionUiStoreApi, useSessionsStore, useSessionsStoreApi } from "./providers";
@@ -71,6 +72,7 @@ export function AppShell() {
   const [fileViewerRequestKey, setFileViewerRequestKey] = useState(0);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [themeMode, setThemeMode] = useState(() => readThemeMode());
+  const [sseConnected, setSseConnected] = useState(false);
   const {
     announcementEnabled,
     announcementLabel,
@@ -153,6 +155,7 @@ export function AppShell() {
   const {
     notificationLabel,
     notificationsEnabled,
+    refreshNotificationFeed,
     replySoundEnabled,
     setReplySoundEnabled,
     toggleNotifications,
@@ -161,8 +164,24 @@ export function AppShell() {
     activeTitle,
     bySessionId,
     playReplyBeep,
+    realtimeConnected: sseConnected,
     suppressedReplySoundSessionIdsRef,
     voiceSettings,
+  });
+
+  useAppShellEvents({
+    activeSessionBackend: activeSession?.agent_backend,
+    activeSessionHistorical: activeSession?.historical === true,
+    activeSessionId,
+    activeSessionPending,
+    activeSessionRuntimeId,
+    items,
+    liveSessionStoreApi,
+    onConnectionChange: setSseConnected,
+    refreshNotificationsFeed: refreshNotificationFeed,
+    sessionUiStoreApi,
+    sessionsStoreApi,
+    workspaceOpen: workspaceOpen || detailsOpen,
   });
 
   useAppShellSessionEffects({
@@ -175,6 +194,7 @@ export function AppShell() {
     backgroundReplySoundPrimedSessionIdsRef,
     items,
     liveSessionStoreApi,
+    realtimeConnected: sseConnected,
     replySoundEnabled,
     sessionUiStoreApi,
     sessionsStoreApi,

--- a/web/src/app/app-shell/useAppShellEvents.ts
+++ b/web/src/app/app-shell/useAppShellEvents.ts
@@ -1,0 +1,167 @@
+import { useEffect, useRef, useState } from "preact/hooks";
+import type { LiveSessionStore } from "../../domains/live-session/store";
+import { openAppEventStream, type AppEventStreamEvent } from "../../domains/events/stream";
+import type { SessionUiStore } from "../../domains/session-ui/store";
+import type { SessionsStore } from "../../domains/sessions/store";
+import { getSessionRuntimeId } from "../../lib/session-identity";
+import type { SessionSummary } from "../../lib/types";
+
+interface UseAppShellEventsOptions {
+  activeSessionBackend?: string;
+  activeSessionHistorical?: boolean;
+  activeSessionId: string | null;
+  activeSessionPending?: boolean;
+  activeSessionRuntimeId?: string | null;
+  items: SessionSummary[];
+  liveSessionStoreApi: LiveSessionStore;
+  onConnectionChange?: (connected: boolean) => void;
+  refreshNotificationsFeed: () => Promise<void>;
+  sessionUiStoreApi: SessionUiStore;
+  sessionsStoreApi: SessionsStore;
+  workspaceOpen: boolean;
+}
+
+function isRecoverableNotFound(error: unknown) {
+  return Boolean(error && typeof error === "object" && (error as { status?: unknown }).status === 404);
+}
+
+export function useAppShellEvents({
+  activeSessionBackend,
+  activeSessionHistorical,
+  activeSessionId,
+  activeSessionPending,
+  activeSessionRuntimeId,
+  items,
+  liveSessionStoreApi,
+  onConnectionChange,
+  refreshNotificationsFeed,
+  sessionUiStoreApi,
+  sessionsStoreApi,
+  workspaceOpen,
+}: UseAppShellEventsOptions) {
+  const [connected, setConnected] = useState(false);
+  const lastSeqRef = useRef(0);
+
+  useEffect(() => {
+    const refreshSessions = () => sessionsStoreApi.refresh().catch(() => undefined);
+    const refreshActiveWorkspace = () => {
+      if (!activeSessionId || !workspaceOpen) {
+        return Promise.resolve();
+      }
+      if ((activeSessionHistorical && activeSessionBackend === "pi") || activeSessionPending) {
+        return Promise.resolve();
+      }
+      return (activeSessionRuntimeId
+        ? sessionUiStoreApi.refresh(activeSessionId, { agentBackend: activeSessionBackend, runtimeId: activeSessionRuntimeId })
+        : sessionUiStoreApi.refresh(activeSessionId, { agentBackend: activeSessionBackend }))
+        .catch((error) => {
+          if (isRecoverableNotFound(error)) {
+            return refreshSessions();
+          }
+          return undefined;
+        });
+    };
+    const pollLiveSession = (sessionId: string, runtimeId?: string | null) => {
+      return (runtimeId
+        ? liveSessionStoreApi.poll(sessionId, runtimeId)
+        : liveSessionStoreApi.poll(sessionId))
+        .catch((error) => {
+          if (isRecoverableNotFound(error)) {
+            return refreshSessions();
+          }
+          return undefined;
+        });
+    };
+    const resyncAll = () => {
+      void refreshSessions();
+      void refreshNotificationsFeed();
+      if (activeSessionId) {
+        void pollLiveSession(activeSessionId, activeSessionRuntimeId);
+      }
+      void refreshActiveWorkspace();
+    };
+
+    const handleEvent = (event: AppEventStreamEvent) => {
+      if (typeof event.seq === "number" && Number.isFinite(event.seq)) {
+        lastSeqRef.current = Math.max(lastSeqRef.current, Math.floor(event.seq));
+      }
+      const eventType = String(event.type || "").trim();
+      if (!eventType) {
+        return;
+      }
+      if (eventType === "stream.resync") {
+        resyncAll();
+        return;
+      }
+      if (eventType === "sessions.invalidate" || eventType === "attention.invalidate") {
+        void refreshSessions();
+        return;
+      }
+      if (eventType === "notifications.invalidate") {
+        void refreshNotificationsFeed();
+        return;
+      }
+
+      const targetRuntimeId = typeof event.runtime_id === "string" && event.runtime_id.trim()
+        ? event.runtime_id.trim()
+        : null;
+      const targetSessionId = typeof event.session_id === "string" && event.session_id.trim()
+        ? event.session_id.trim()
+        : null;
+      const session = items.find((item) => (
+        (targetSessionId && item.session_id === targetSessionId)
+        || (targetRuntimeId && getSessionRuntimeId(item) === targetRuntimeId)
+      )) ?? null;
+
+      if (eventType === "session.workspace.invalidate") {
+        if (!workspaceOpen || !activeSessionId || !targetSessionId) {
+          return;
+        }
+        if (activeSessionId !== targetSessionId && activeSessionRuntimeId !== targetRuntimeId) {
+          return;
+        }
+        void refreshActiveWorkspace();
+        return;
+      }
+
+      if (eventType === "session.live.invalidate" || eventType === "session.transport.invalidate") {
+        if (!session) {
+          void refreshSessions();
+          return;
+        }
+        if ((session.historical && session.agent_backend === "pi") || session.pending_startup) {
+          void refreshSessions();
+          return;
+        }
+        const runtimeId = targetRuntimeId || getSessionRuntimeId(session);
+        const liveState = liveSessionStoreApi.getState();
+        const isTracked = session.session_id === activeSessionId
+          || session.busy === true
+          || typeof liveState.offsetsBySessionId[session.session_id] === "number";
+        if (!isTracked) {
+          return;
+        }
+        void pollLiveSession(session.session_id, runtimeId);
+        if (eventType === "session.transport.invalidate") {
+          void refreshSessions();
+        }
+      }
+    };
+
+    const stream = openAppEventStream({
+      cursor: lastSeqRef.current,
+      onEvent: handleEvent,
+      onStateChange: (state) => {
+        const isOpen = state === "open";
+        setConnected(isOpen);
+        onConnectionChange?.(isOpen);
+      },
+    });
+
+    return () => {
+      stream.close();
+    };
+  }, [activeSessionBackend, activeSessionHistorical, activeSessionId, activeSessionPending, activeSessionRuntimeId, items, liveSessionStoreApi, onConnectionChange, refreshNotificationsFeed, sessionUiStoreApi, sessionsStoreApi, workspaceOpen]);
+
+  return { connected };
+}

--- a/web/src/app/app-shell/useAppShellEvents.ts
+++ b/web/src/app/app-shell/useAppShellEvents.ts
@@ -186,9 +186,6 @@ export function useAppShellEvents({
           return;
         }
         void pollLiveSession(session.session_id, runtimeId);
-        if (eventType === "session.transport.invalidate") {
-          void refreshSessions();
-        }
       }
     };
 

--- a/web/src/app/app-shell/useAppShellEvents.ts
+++ b/web/src/app/app-shell/useAppShellEvents.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "preact/hooks";
-import type { LiveSessionStore } from "../../domains/live-session/store";
 import { openAppEventStream, type AppEventStreamEvent } from "../../domains/events/stream";
+import type { LiveSessionStore } from "../../domains/live-session/store";
 import type { SessionUiStore } from "../../domains/session-ui/store";
 import type { SessionsStore } from "../../domains/sessions/store";
 import { getSessionRuntimeId } from "../../lib/session-identity";
@@ -18,6 +18,18 @@ interface UseAppShellEventsOptions {
   refreshNotificationsFeed: () => Promise<void>;
   sessionUiStoreApi: SessionUiStore;
   sessionsStoreApi: SessionsStore;
+  workspaceOpen: boolean;
+}
+
+interface LatestAppShellEventContext {
+  activeSessionBackend?: string;
+  activeSessionHistorical?: boolean;
+  activeSessionId: string | null;
+  activeSessionPending?: boolean;
+  activeSessionRuntimeId?: string | null;
+  items: SessionSummary[];
+  onConnectionChange?: (connected: boolean) => void;
+  refreshNotificationsFeed: () => Promise<void>;
   workspaceOpen: boolean;
 }
 
@@ -41,19 +53,45 @@ export function useAppShellEvents({
 }: UseAppShellEventsOptions) {
   const [connected, setConnected] = useState(false);
   const lastSeqRef = useRef(0);
+  const latestRef = useRef<LatestAppShellEventContext>({
+    activeSessionBackend,
+    activeSessionHistorical,
+    activeSessionId,
+    activeSessionPending,
+    activeSessionRuntimeId,
+    items,
+    onConnectionChange,
+    refreshNotificationsFeed,
+    workspaceOpen,
+  });
+
+  useEffect(() => {
+    latestRef.current = {
+      activeSessionBackend,
+      activeSessionHistorical,
+      activeSessionId,
+      activeSessionPending,
+      activeSessionRuntimeId,
+      items,
+      onConnectionChange,
+      refreshNotificationsFeed,
+      workspaceOpen,
+    };
+  }, [activeSessionBackend, activeSessionHistorical, activeSessionId, activeSessionPending, activeSessionRuntimeId, items, onConnectionChange, refreshNotificationsFeed, workspaceOpen]);
 
   useEffect(() => {
     const refreshSessions = () => sessionsStoreApi.refresh().catch(() => undefined);
     const refreshActiveWorkspace = () => {
-      if (!activeSessionId || !workspaceOpen) {
+      const latest = latestRef.current;
+      if (!latest.activeSessionId || !latest.workspaceOpen) {
         return Promise.resolve();
       }
-      if ((activeSessionHistorical && activeSessionBackend === "pi") || activeSessionPending) {
+      if ((latest.activeSessionHistorical && latest.activeSessionBackend === "pi") || latest.activeSessionPending) {
         return Promise.resolve();
       }
-      return (activeSessionRuntimeId
-        ? sessionUiStoreApi.refresh(activeSessionId, { agentBackend: activeSessionBackend, runtimeId: activeSessionRuntimeId })
-        : sessionUiStoreApi.refresh(activeSessionId, { agentBackend: activeSessionBackend }))
+      return (latest.activeSessionRuntimeId
+        ? sessionUiStoreApi.refresh(latest.activeSessionId, { agentBackend: latest.activeSessionBackend, runtimeId: latest.activeSessionRuntimeId })
+        : sessionUiStoreApi.refresh(latest.activeSessionId, { agentBackend: latest.activeSessionBackend }))
         .catch((error) => {
           if (isRecoverableNotFound(error)) {
             return refreshSessions();
@@ -73,12 +111,17 @@ export function useAppShellEvents({
         });
     };
     const resyncAll = () => {
+      const latest = latestRef.current;
       void refreshSessions();
-      void refreshNotificationsFeed();
-      if (activeSessionId) {
-        void pollLiveSession(activeSessionId, activeSessionRuntimeId);
+      void latest.refreshNotificationsFeed();
+      if (latest.activeSessionId) {
+        void pollLiveSession(latest.activeSessionId, latest.activeSessionRuntimeId);
       }
       void refreshActiveWorkspace();
+    };
+    const updateConnectionState = (isOpen: boolean) => {
+      setConnected(isOpen);
+      latestRef.current.onConnectionChange?.(isOpen);
     };
 
     const handleEvent = (event: AppEventStreamEvent) => {
@@ -98,26 +141,27 @@ export function useAppShellEvents({
         return;
       }
       if (eventType === "notifications.invalidate") {
-        void refreshNotificationsFeed();
+        void latestRef.current.refreshNotificationsFeed();
         return;
       }
 
+      const latest = latestRef.current;
       const targetRuntimeId = typeof event.runtime_id === "string" && event.runtime_id.trim()
         ? event.runtime_id.trim()
         : null;
       const targetSessionId = typeof event.session_id === "string" && event.session_id.trim()
         ? event.session_id.trim()
         : null;
-      const session = items.find((item) => (
+      const session = latest.items.find((item) => (
         (targetSessionId && item.session_id === targetSessionId)
         || (targetRuntimeId && getSessionRuntimeId(item) === targetRuntimeId)
       )) ?? null;
 
       if (eventType === "session.workspace.invalidate") {
-        if (!workspaceOpen || !activeSessionId || !targetSessionId) {
+        if (!latest.workspaceOpen || !latest.activeSessionId || !targetSessionId) {
           return;
         }
-        if (activeSessionId !== targetSessionId && activeSessionRuntimeId !== targetRuntimeId) {
+        if (latest.activeSessionId !== targetSessionId && latest.activeSessionRuntimeId !== targetRuntimeId) {
           return;
         }
         void refreshActiveWorkspace();
@@ -135,7 +179,7 @@ export function useAppShellEvents({
         }
         const runtimeId = targetRuntimeId || getSessionRuntimeId(session);
         const liveState = liveSessionStoreApi.getState();
-        const isTracked = session.session_id === activeSessionId
+        const isTracked = session.session_id === latest.activeSessionId
           || session.busy === true
           || typeof liveState.offsetsBySessionId[session.session_id] === "number";
         if (!isTracked) {
@@ -152,16 +196,14 @@ export function useAppShellEvents({
       cursor: lastSeqRef.current,
       onEvent: handleEvent,
       onStateChange: (state) => {
-        const isOpen = state === "open";
-        setConnected(isOpen);
-        onConnectionChange?.(isOpen);
+        updateConnectionState(state === "open");
       },
     });
 
     return () => {
       stream.close();
     };
-  }, [activeSessionBackend, activeSessionHistorical, activeSessionId, activeSessionPending, activeSessionRuntimeId, items, liveSessionStoreApi, onConnectionChange, refreshNotificationsFeed, sessionUiStoreApi, sessionsStoreApi, workspaceOpen]);
+  }, [liveSessionStoreApi, sessionUiStoreApi, sessionsStoreApi]);
 
   return { connected };
 }

--- a/web/src/app/app-shell/useAppShellNotifications.ts
+++ b/web/src/app/app-shell/useAppShellNotifications.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { api } from "../../lib/api";
 import type { NotificationSubscriptionStateResponse, VoiceSettingsResponse } from "../../lib/types";
 import { toPublicAssetUrl } from "../../lib/publicAssetUrl";
@@ -15,6 +15,8 @@ import {
 const NOTIFICATION_MESSAGE_RETRY_MS = 15000;
 const FINAL_NOTIFICATION_SUMMARY_STATUSES = new Set(["sent", "skipped", "error"]);
 const REPLY_SOUND_TEXT_DEDUPE_MS = 30000;
+const NOTIFICATION_FEED_POLL_MS = 5000;
+const SSE_NOTIFICATION_FALLBACK_MS = 60000;
 
 function isDocumentVisible() {
   if (typeof document === "undefined") {
@@ -33,6 +35,7 @@ interface UseAppShellNotificationsOptions {
   activeTitle: string;
   bySessionId: Record<string, unknown[]>;
   playReplyBeep(): void;
+  realtimeConnected?: boolean;
   suppressedReplySoundSessionIdsRef: { current: Set<string> };
   voiceSettings: VoiceSettingsResponse;
 }
@@ -42,6 +45,7 @@ export function useAppShellNotifications({
   activeTitle,
   bySessionId,
   playReplyBeep,
+  realtimeConnected = false,
   suppressedReplySoundSessionIdsRef,
   voiceSettings,
 }: UseAppShellNotificationsOptions) {
@@ -177,63 +181,56 @@ export function useAppShellNotifications({
     if (id) deliveredNotificationIdsRef.current.add(id);
   };
 
-  useEffect(() => {
+  const refreshNotificationFeed = useCallback(async (prime = false) => {
     const desktopNotificationsEnabled = (
       notificationsEnabled
       && notificationPermission === "granted"
       && typeof Notification !== "undefined"
       && notificationDeviceClass() === "desktop"
     );
-
     if (!pageVisible || (!replySoundEnabled && !desktopNotificationsEnabled)) {
       return;
     }
-
-    notificationFeedCursorRef.current = Date.now() / 1000;
-    let cancelled = false;
-
-    const pollFeed = async (prime = false) => {
-      const response = await api.getNotificationsFeed(notificationFeedCursorRef.current);
-      if (cancelled) return;
-      let maxSeen = notificationFeedCursorRef.current;
-      for (const item of response.items || []) {
-        const updatedTs = Number(item.updated_ts || 0);
-        if (updatedTs > maxSeen) maxSeen = updatedTs;
-        if (prime) continue;
-        const messageId = typeof item.message_id === "string" ? item.message_id.trim() : "";
-        const replySoundKey = messageId ? `id:${messageId}` : "";
-        const replySoundSessionId = typeof (item as any).session_id === "string"
-          ? String((item as any).session_id)
-          : String(item.session_display_name || "");
-        const replySoundRow = {
-          message_id: messageId,
-          notification_text: item.notification_text,
-        } satisfies Record<string, unknown>;
-        if (replySoundEnabled && replySoundKey && !hasPlayedReplySound(replySoundSessionId, replySoundRow, replySoundKey)) {
-          playReplyBeepRef.current();
-          rememberPlayedReplySound(replySoundSessionId, replySoundRow);
-        }
-        if (desktopNotificationsEnabled) {
-          showDesktopNotification(
-            String(item.session_display_name || "Session"),
-            String(item.notification_text || ""),
-            item.message_id,
-          );
-        }
+    const response = await api.getNotificationsFeed(notificationFeedCursorRef.current);
+    let maxSeen = notificationFeedCursorRef.current;
+    for (const item of response.items || []) {
+      const updatedTs = Number(item.updated_ts || 0);
+      if (updatedTs > maxSeen) maxSeen = updatedTs;
+      if (prime) continue;
+      const messageId = typeof item.message_id === "string" ? item.message_id.trim() : "";
+      const replySoundKey = messageId ? `id:${messageId}` : "";
+      const replySoundSessionId = typeof (item as any).session_id === "string"
+        ? String((item as any).session_id)
+        : String(item.session_display_name || "");
+      const replySoundRow = {
+        message_id: messageId,
+        notification_text: item.notification_text,
+      } satisfies Record<string, unknown>;
+      if (replySoundEnabled && replySoundKey && !hasPlayedReplySound(replySoundSessionId, replySoundRow, replySoundKey)) {
+        playReplyBeepRef.current();
+        rememberPlayedReplySound(replySoundSessionId, replySoundRow);
       }
-      notificationFeedCursorRef.current = maxSeen;
-    };
+      if (desktopNotificationsEnabled) {
+        showDesktopNotification(
+          String(item.session_display_name || "Session"),
+          String(item.notification_text || ""),
+          item.message_id,
+        );
+      }
+    }
+    notificationFeedCursorRef.current = maxSeen;
+  }, [notificationPermission, notificationsEnabled, pageVisible, replySoundEnabled]);
 
-    void pollFeed(true);
+  useEffect(() => {
+    notificationFeedCursorRef.current = Date.now() / 1000;
+    void refreshNotificationFeed(true);
     const intervalId = window.setInterval(() => {
-      void pollFeed(false);
-    }, 5000);
-
+      void refreshNotificationFeed(false);
+    }, realtimeConnected ? SSE_NOTIFICATION_FALLBACK_MS : NOTIFICATION_FEED_POLL_MS);
     return () => {
-      cancelled = true;
       window.clearInterval(intervalId);
     };
-  }, [notificationPermission, notificationsEnabled, pageVisible, replySoundEnabled]);
+  }, [realtimeConnected, refreshNotificationFeed]);
 
   useEffect(() => {
     const nextSeen = new Set<string>();
@@ -403,6 +400,7 @@ export function useAppShellNotifications({
     notificationLabel,
     notificationsEnabled,
     pushNotificationsEnabled,
+    refreshNotificationFeed: () => refreshNotificationFeed(false),
     replySoundEnabled,
     setReplySoundEnabled,
     toggleNotifications,

--- a/web/src/app/app-shell/useAppShellSessionEffects.ts
+++ b/web/src/app/app-shell/useAppShellSessionEffects.ts
@@ -14,6 +14,7 @@ interface UseAppShellSessionEffectsOptions {
   activeSessionLiveBusy: boolean;
   items: SessionSummary[];
   liveSessionStoreApi: LiveSessionStore;
+  realtimeConnected?: boolean;
   replySoundEnabled: boolean;
   sessionUiStoreApi: SessionUiStore;
   sessionsStoreApi: SessionsStore;
@@ -29,6 +30,10 @@ const ACTIVE_BUSY_LIVE_REFRESH_MS = 2000;
 const ACTIVE_IDLE_LIVE_REFRESH_MS = 12000;
 const BACKGROUND_BUSY_LIVE_REFRESH_MS = 5000;
 const WORKSPACE_REFRESH_MS = 15000;
+const SSE_SESSIONS_FALLBACK_MS = 60000;
+const SSE_ACTIVE_LIVE_FALLBACK_MS = 30000;
+const SSE_BACKGROUND_LIVE_FALLBACK_MS = 30000;
+const SSE_WORKSPACE_FALLBACK_MS = 60000;
 
 function isDocumentVisible() {
   if (typeof document === "undefined") {
@@ -46,6 +51,7 @@ export function useAppShellSessionEffects({
   activeSessionLiveBusy,
   items,
   liveSessionStoreApi,
+  realtimeConnected = false,
   replySoundEnabled,
   sessionUiStoreApi,
   sessionsStoreApi,
@@ -56,10 +62,14 @@ export function useAppShellSessionEffects({
 }: UseAppShellSessionEffectsOptions) {
   const [pageVisible, setPageVisible] = useState(isDocumentVisible);
   const hasBusySession = items.some((session) => Boolean(session.busy || session.pending_startup));
-  const sessionsRefreshIntervalMs = hasBusySession ? BUSY_SESSIONS_REFRESH_MS : IDLE_SESSIONS_REFRESH_MS;
+  const sessionsRefreshIntervalMs = realtimeConnected
+    ? SSE_SESSIONS_FALLBACK_MS
+    : (hasBusySession ? BUSY_SESSIONS_REFRESH_MS : IDLE_SESSIONS_REFRESH_MS);
   const activeSessionBusy = activeSessionLiveBusy
     || items.some((session) => session.session_id === activeSessionId && session.busy);
-  const activeLiveRefreshIntervalMs = activeSessionBusy ? ACTIVE_BUSY_LIVE_REFRESH_MS : ACTIVE_IDLE_LIVE_REFRESH_MS;
+  const activeLiveRefreshIntervalMs = realtimeConnected
+    ? SSE_ACTIVE_LIVE_FALLBACK_MS
+    : (activeSessionBusy ? ACTIVE_BUSY_LIVE_REFRESH_MS : ACTIVE_IDLE_LIVE_REFRESH_MS);
 
   useEffect(() => {
     const handleVisibilityChange = () => {
@@ -142,9 +152,9 @@ export function useAppShellSessionEffects({
       (activeSessionRuntimeId
         ? sessionUiStoreApi.refresh(activeSessionId, { agentBackend: activeSessionBackend, runtimeId: activeSessionRuntimeId })
         : sessionUiStoreApi.refresh(activeSessionId, { agentBackend: activeSessionBackend })).catch(recoverMissingSession);
-    }, WORKSPACE_REFRESH_MS);
+    }, realtimeConnected ? SSE_WORKSPACE_FALLBACK_MS : WORKSPACE_REFRESH_MS);
     return () => window.clearInterval(intervalId);
-  }, [activeSessionBackend, activeSessionHistorical, activeSessionId, activeSessionPending, activeSessionRuntimeId, pageVisible, sessionUiStoreApi, sessionsStoreApi, workspaceOpen]);
+  }, [activeSessionBackend, activeSessionHistorical, activeSessionId, activeSessionPending, activeSessionRuntimeId, pageVisible, realtimeConnected, sessionUiStoreApi, sessionsStoreApi, workspaceOpen]);
 
   useEffect(() => {
     if (!pageVisible || !replySoundEnabled) {
@@ -191,7 +201,10 @@ export function useAppShellSessionEffects({
     };
 
     pollBackgroundBusySessions();
-    const intervalId = window.setInterval(pollBackgroundBusySessions, BACKGROUND_BUSY_LIVE_REFRESH_MS);
+    const intervalId = window.setInterval(
+      pollBackgroundBusySessions,
+      realtimeConnected ? SSE_BACKGROUND_LIVE_FALLBACK_MS : BACKGROUND_BUSY_LIVE_REFRESH_MS,
+    );
     return () => window.clearInterval(intervalId);
-  }, [activeSessionId, backgroundReplySoundPrimedSessionIdsRef, items, liveSessionStoreApi, pageVisible, replySoundEnabled]);
+  }, [activeSessionId, backgroundReplySoundPrimedSessionIdsRef, items, liveSessionStoreApi, pageVisible, realtimeConnected, replySoundEnabled]);
 }

--- a/web/src/domains/events/stream.ts
+++ b/web/src/domains/events/stream.ts
@@ -1,0 +1,79 @@
+export interface AppEventStreamEvent {
+  seq?: number;
+  type?: string;
+  session_id?: string;
+  runtime_id?: string | null;
+  reason?: string;
+  ts?: number;
+  hints?: Record<string, unknown>;
+}
+
+export interface OpenAppEventStreamOptions {
+  cursor?: number;
+  onEvent(event: AppEventStreamEvent): void;
+  onStateChange?(state: "connecting" | "open" | "error" | "closed"): void;
+}
+
+const EVENT_TYPES = [
+  "sessions.invalidate",
+  "session.live.invalidate",
+  "session.workspace.invalidate",
+  "notifications.invalidate",
+  "attention.invalidate",
+  "session.transport.invalidate",
+  "stream.resync",
+] as const;
+
+function buildEventsUrl(cursor?: number) {
+  if (typeof window === "undefined") {
+    return "/api/events";
+  }
+  const url = new URL("/api/events", window.location.origin);
+  if (typeof cursor === "number" && Number.isFinite(cursor) && cursor > 0) {
+    url.searchParams.set("cursor", String(Math.floor(cursor)));
+  }
+  return `${url.pathname}${url.search}`;
+}
+
+function parseEventData(raw: string): AppEventStreamEvent | null {
+  try {
+    const payload = JSON.parse(raw);
+    return payload && typeof payload === "object" ? payload as AppEventStreamEvent : null;
+  } catch {
+    return null;
+  }
+}
+
+export function openAppEventStream({ cursor, onEvent, onStateChange }: OpenAppEventStreamOptions) {
+  if (typeof window === "undefined" || typeof EventSource === "undefined") {
+    return { close() {} };
+  }
+
+  onStateChange?.("connecting");
+  const source = new EventSource(buildEventsUrl(cursor));
+  const handleEvent = (event: MessageEvent<string>) => {
+    const payload = parseEventData(String(event.data || ""));
+    if (!payload) {
+      return;
+    }
+    onEvent(payload);
+  };
+
+  source.onopen = () => {
+    onStateChange?.("open");
+  };
+  source.onerror = () => {
+    onStateChange?.("error");
+  };
+  source.onmessage = handleEvent;
+  for (const eventType of EVENT_TYPES) {
+    source.addEventListener(eventType, handleEvent as EventListener);
+  }
+
+  return {
+    close() {
+      source.close();
+      onStateChange?.("closed");
+    },
+  };
+}

--- a/web/src/domains/session-ui/store.test.ts
+++ b/web/src/domains/session-ui/store.test.ts
@@ -126,4 +126,30 @@ describe("createSessionUiStore", () => {
       loading: false,
     });
   });
+
+  it("reuses an in-flight refresh for the same session and runtime", async () => {
+    const deferred = createDeferred<Record<string, unknown>>();
+    vi.mocked(api.getWorkspace).mockReturnValueOnce(deferred.promise as any);
+
+    const store = createSessionUiStore();
+    const first = store.refresh("s1", { runtimeId: "rt-1" });
+    const second = store.refresh("s1", { runtimeId: "rt-1" });
+
+    expect(api.getWorkspace).toHaveBeenCalledTimes(1);
+
+    deferred.resolve({
+      runtime_id: "rt-1",
+      diagnostics: { todo_snapshot: { progress_text: "1/1 completed" } },
+      queue: { items: ["queued"] },
+    });
+    await Promise.all([first, second]);
+
+    expect(store.getState()).toEqual({
+      sessionId: "s1",
+      runtimeId: "rt-1",
+      diagnostics: { todo_snapshot: { progress_text: "1/1 completed" } },
+      queue: { items: ["queued"] },
+      loading: false,
+    });
+  });
 });

--- a/web/src/domains/session-ui/store.ts
+++ b/web/src/domains/session-ui/store.ts
@@ -29,6 +29,7 @@ export function createSessionUiStore(): SessionUiStore {
   };
   const listeners = new Set<() => void>();
   let currentRefreshId = 0;
+  let inFlightRefresh: { key: string; promise: Promise<void> } | null = null;
 
   const emit = () => {
     for (const listener of listeners) {
@@ -45,6 +46,11 @@ export function createSessionUiStore(): SessionUiStore {
       };
     },
     async refresh(sessionId: string, _options?: SessionUiRefreshOptions) {
+      const refreshKey = `${sessionId}:${String(_options?.runtimeId || "")}`;
+      if (inFlightRefresh && inFlightRefresh.key === refreshKey) {
+        return inFlightRefresh.promise;
+      }
+
       const refreshId = ++currentRefreshId;
       const preserveCurrentState = state.sessionId === sessionId;
       state = {
@@ -56,31 +62,41 @@ export function createSessionUiStore(): SessionUiStore {
       };
       emit();
 
-      try {
-        const workspace = _options?.runtimeId
-          ? await api.getWorkspace(sessionId, undefined, _options.runtimeId)
-          : await api.getWorkspace(sessionId);
-        if (refreshId !== currentRefreshId) {
-          return;
-        }
+      let request: Promise<void> | null = null;
+      request = (async () => {
+        try {
+          const workspace = _options?.runtimeId
+            ? await api.getWorkspace(sessionId, undefined, _options.runtimeId)
+            : await api.getWorkspace(sessionId);
+          if (refreshId !== currentRefreshId) {
+            return;
+          }
 
-        state = {
-          sessionId,
-          runtimeId: typeof workspace.runtime_id === "string" && workspace.runtime_id.trim()
-            ? workspace.runtime_id
-            : (_options?.runtimeId ?? null),
-          diagnostics: (workspace.diagnostics ?? null) as Record<string, unknown> | null,
-          queue: (workspace.queue ?? null) as Record<string, unknown> | null,
-          loading: false,
-        };
-        emit();
-      } catch (error) {
-        if (refreshId === currentRefreshId) {
-          state = { ...state, loading: false };
+          state = {
+            sessionId,
+            runtimeId: typeof workspace.runtime_id === "string" && workspace.runtime_id.trim()
+              ? workspace.runtime_id
+              : (_options?.runtimeId ?? null),
+            diagnostics: (workspace.diagnostics ?? null) as Record<string, unknown> | null,
+            queue: (workspace.queue ?? null) as Record<string, unknown> | null,
+            loading: false,
+          };
           emit();
-          throw error;
+        } catch (error) {
+          if (refreshId === currentRefreshId) {
+            state = { ...state, loading: false };
+            emit();
+            throw error;
+          }
+        } finally {
+          if (inFlightRefresh?.promise === request) {
+            inFlightRefresh = null;
+          }
         }
-      }
+      })();
+
+      inFlightRefresh = { key: refreshKey, promise: request };
+      return request;
     },
   };
 }

--- a/web/src/domains/sessions/store.test.ts
+++ b/web/src/domains/sessions/store.test.ts
@@ -165,4 +165,21 @@ describe("createSessionsStore", () => {
 
     expect(store.getState().items.map((session) => session.session_id)).toEqual(["runtime-1", "runtime-3"]);
   });
+
+  it("reuses an in-flight refresh for repeated identical requests", async () => {
+    let resolveRefresh!: (value: unknown) => void;
+    vi.mocked(api.listSessions).mockReturnValueOnce(new Promise((resolve) => {
+      resolveRefresh = resolve;
+    }) as never);
+    const store = createSessionsStore();
+
+    const first = store.refresh();
+    const second = store.refresh();
+
+    expect(api.listSessions).toHaveBeenCalledTimes(1);
+    resolveRefresh({ sessions: [{ session_id: "s1" }] });
+    await Promise.all([first, second]);
+
+    expect(store.getState().items).toEqual([{ session_id: "s1" }]);
+  });
 });

--- a/web/src/domains/sessions/store.ts
+++ b/web/src/domains/sessions/store.ts
@@ -76,6 +76,7 @@ export function createSessionsStore(): SessionsStore {
   let currentBootstrapRefreshId = 0;
   let hasResolvedInitialSelection = false;
   let loadedLimit = PAGE_SIZE;
+  let inFlightRefresh: { key: string; promise: Promise<void> } | null = null;
 
   const emit = () => {
     for (const listener of listeners) {
@@ -84,47 +85,62 @@ export function createSessionsStore(): SessionsStore {
   };
 
   const refresh = async (options?: RefreshSessionsOptions) => {
+    const refreshKey = `${loadedLimit}:${options?.preferNewest === true ? "newest" : "preserve"}`;
+    if (inFlightRefresh && inFlightRefresh.key === refreshKey) {
+      return inFlightRefresh.promise;
+    }
+
     const refreshId = ++currentRefreshId;
     state = { ...state, loading: true };
     emit();
 
-    try {
-      const data = await api.listSessions({ limit: loadedLimit });
-      if (refreshId !== currentRefreshId) {
-        return;
-      }
-      const deduped = dedupeSessions(Array.isArray(data.sessions) ? data.sessions : []);
-      const sessions = deduped.sessions;
-      const representativeBySessionId = deduped.representativeBySessionId;
-      const sessionIds = new Set(sessions.map((session) => session.session_id));
-      const activeRepresentativeSessionId = state.activeSessionId
-        ? representativeBySessionId.get(state.activeSessionId) ?? state.activeSessionId
-        : null;
-      const preservedActiveSessionId = activeRepresentativeSessionId && sessionIds.has(activeRepresentativeSessionId)
-        ? activeRepresentativeSessionId
-        : null;
-      const nextActiveSessionId = options?.preferNewest
-        ? sessions[0]?.session_id ?? null
-        : preservedActiveSessionId
-          ?? (!hasResolvedInitialSelection ? sessions[0]?.session_id ?? null : null);
-      if (nextActiveSessionId) {
-        hasResolvedInitialSelection = true;
-      }
-      state = {
-        ...state,
-        items: sessions,
-        activeSessionId: nextActiveSessionId,
-        loading: false,
-        remainingCount: Math.max(0, Number(data.remaining_count || 0)),
-      };
-      emit();
-    } catch (error) {
-      if (refreshId === currentRefreshId) {
-        state = { ...state, loading: false };
+    let request: Promise<void> | null = null;
+    request = (async () => {
+      try {
+        const data = await api.listSessions({ limit: loadedLimit });
+        if (refreshId !== currentRefreshId) {
+          return;
+        }
+        const deduped = dedupeSessions(Array.isArray(data.sessions) ? data.sessions : []);
+        const sessions = deduped.sessions;
+        const representativeBySessionId = deduped.representativeBySessionId;
+        const sessionIds = new Set(sessions.map((session) => session.session_id));
+        const activeRepresentativeSessionId = state.activeSessionId
+          ? representativeBySessionId.get(state.activeSessionId) ?? state.activeSessionId
+          : null;
+        const preservedActiveSessionId = activeRepresentativeSessionId && sessionIds.has(activeRepresentativeSessionId)
+          ? activeRepresentativeSessionId
+          : null;
+        const nextActiveSessionId = options?.preferNewest
+          ? sessions[0]?.session_id ?? null
+          : preservedActiveSessionId
+            ?? (!hasResolvedInitialSelection ? sessions[0]?.session_id ?? null : null);
+        if (nextActiveSessionId) {
+          hasResolvedInitialSelection = true;
+        }
+        state = {
+          ...state,
+          items: sessions,
+          activeSessionId: nextActiveSessionId,
+          loading: false,
+          remainingCount: Math.max(0, Number(data.remaining_count || 0)),
+        };
         emit();
-        throw error;
+      } catch (error) {
+        if (refreshId === currentRefreshId) {
+          state = { ...state, loading: false };
+          emit();
+          throw error;
+        }
+      } finally {
+        if (inFlightRefresh?.promise === request) {
+          inFlightRefresh = null;
+        }
       }
-    }
+    })();
+
+    inFlightRefresh = { key: refreshKey, promise: request };
+    return request;
   };
 
   return {


### PR DESCRIPTION
## Summary
- add `/api/events` as an SSE invalidation channel backed by a bounded event hub
- wire backend invalidation publishes for session/live/workspace/notification updates
- add browser-side SSE consumption so realtime updates no longer depend on aggressive polling
- stabilize the EventSource lifecycle and coalesce duplicate frontend refreshes

## Validation
- `cd /root/code/codoxear-sse-server-push/web && npm test -- AppShell.test.tsx src/domains/sessions/store.test.ts src/domains/session-ui/store.test.ts src/domains/live-session/store.test.ts`
- `cd /root/code/codoxear-sse-server-push/web && npm run build`
